### PR TITLE
for PR-1378

### DIFF
--- a/Paubox_Java/paubox-java/src/test/TestEmailService.java
+++ b/Paubox_Java/paubox-java/src/test/TestEmailService.java
@@ -140,7 +140,7 @@ public class TestEmailService {
 	@Test
 	public void testSendMessageForErrorMail() {
 		try {
-			message.getHeader().setFrom("renee@undefeatedgames1.com");
+            message.setRecipients(new String[] { "bogus@undefeatedgames123.@com" });
 			SendMessageResponse response = email.sendMessage(message);
 			assertNotNull(response);
 			assertNull(response.getSourceTrackingId());


### PR DESCRIPTION
CHORE - Run all JUnit tests to ensure httpclient upgrade does not break exisiting functionality
[[PAUB-1378](https://paubox.atlassian.net/browse/PAUB-1378)

DESCRIPTION:
upgrades http client in paubox-java SDK to 4.5.13
jackson-databind to 2.13.2.1
junit to 4.12

CHANGELIST:
modified: TestEmailService.java -> method (junit test) testSendMessageForErrorMail() to use a malformed email recipient address, to achieve the desired result from the API of an error response.