### PR TITLE
PAUB-1417

### DIFF
--- a/Paubox_Java/paubox-java/src/com/paubox/config/ConfigurationManager.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/config/ConfigurationManager.java
@@ -9,12 +9,13 @@ import java.util.Properties;
 import com.paubox.common.Constants;
 
 public class ConfigurationManager {
-	
+
+	private static Properties properties;
 	private static void readProperties(String fileAndPath){
 		try {
 			File file = new File(fileAndPath);
 			FileInputStream fileInput = new FileInputStream(file);
-			Properties properties = new Properties();
+			properties = new Properties();
 			properties.load(fileInput);
 			fileInput.close();
 			
@@ -33,9 +34,12 @@ public class ConfigurationManager {
 		Constants.API_USER=properties.getProperty("APIUSER");
 		
 	}
-	
+
 	public static void getProperties(String fileAndPath){
 		readProperties(fileAndPath);
+	}
+	public static String getProperty(String propertyName){
+		return properties.getProperty(propertyName);
 	}
 
 }

--- a/Paubox_Java/paubox-java/src/test/TestAPIHelper.java
+++ b/Paubox_Java/paubox-java/src/test/TestAPIHelper.java
@@ -3,7 +3,10 @@
  */
 package test;
 
+import com.paubox.config.ConfigurationManager;
 import org.apache.http.client.ClientProtocolException;
+import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.Test;
 
 import com.paubox.service.APIHelper;
@@ -12,15 +15,31 @@ import junit.framework.TestCase;
 
 public class TestAPIHelper extends TestCase {
 
+	String baseUrl;
+	String authToken;
+
+
 	/**
 	 * Test method for
 	 * {@link com.paubox.service.APIHelper#callToAPIByGet(java.lang.String, java.lang.String)}.
 	 */
 
+	public void setParams() {
+		String propFile = System.getProperty("properties");
+		if (propFile == null || propFile.equals(""))
+		{
+			propFile = "src/test/config.properties";
+		}
+		ConfigurationManager.getProperties(propFile);
+		baseUrl = ConfigurationManager.getProperty("BASE_URL") + "/" + ConfigurationManager.getProperty("APIUSER") + "/";
+		authToken = "Token token=" + ConfigurationManager.getProperty("APIKEY");
+	}
+
+
 	@Test
 	public void testCallToAPIByGetForSuccess() {
-		String url = "https://api.paubox.net/v1/undefeatedgames/message_receipt?sourceTrackingId=97b18032-59d5-47c7-a7c6-a2ed27f0f44e";
-		String authToken = "Token token=6f7c0110a47f82e7bff933f68cc8d7ec";
+		setParams();
+		String url = baseUrl + "/message_receipt?sourceTrackingId=97b18032-59d5-47c7-a7c6-a2ed27f0f44e";
 		try {
 			String response =  APIHelper.callToAPIByGet(url, authToken);
 			assertNotNull(response);
@@ -31,11 +50,10 @@ public class TestAPIHelper extends TestCase {
 
 	@Test(expected = Exception.class)
 	public void testCallToAPIByGetForAuth() {
-		String url = "https://api.paubox.net/v1/undefeatedgames/message_receipt?sourceTrackingId=97b18032-59d5-47c7-a7c6-a2ed27f0f44e";
-		// token is wrong. it gives 401 error code
-		String authToken = "Token token=6f7c0110a47f82e7bff933f68cc8d7ec00";
+		setParams();
+		String url = baseUrl + "/message_receipt?sourceTrackingId=97b18032-59d5-47c7-a7c6-a2ed27f0f44e";
 		try {
-			String response =  APIHelper.callToAPIByGet(url, authToken);
+			String response =  APIHelper.callToAPIByGet(url, "Token token=b00000964da30b000b7e00000e27a1b000000000");
 			assertNotNull(response);
 		} catch (Exception e) {
 			e.printStackTrace();
@@ -45,11 +63,14 @@ public class TestAPIHelper extends TestCase {
 	@Test(expected = ClientProtocolException.class)
 	public void testCallToAPIByGetForUrl() {
 		// url is mallformed.
-		String url = "https:api.paubox.net/v1/undefeatedgames/message_receipt?sourceTrackingId=97b18032-59d5-47c7-a7c6-a2ed27f0f44e";
-		String authToken = "Token token=6f7c0110a47f82e7bff933f68cc8d7ec";
+		setParams();
+		String url = baseUrl + "/message_receipt?sourceTrackingId=97b18032-59d5-47c7-a7c6-a2ed27f0f44e";
+		url = url.replaceFirst("//", "");
 		try {
 			String response =  APIHelper.callToAPIByGet(url, authToken);
 			assertNotNull(response);
+		} catch (ClientProtocolException e) {
+//			e.printStackTrace();
 		} catch (Exception e) {
 			e.printStackTrace();
 		}
@@ -57,8 +78,8 @@ public class TestAPIHelper extends TestCase {
 
 	@Test
 	public void testCallToAPIByPostForSuccess() {
-		String url = "https://api.paubox.net/v1/undefeatedgames/messages";
-		String authToken = "Token token=6f7c0110a47f82e7bff933f68cc8d7ec";
+		setParams();
+		String url = baseUrl + "/messages";
 		String requestBody = "{\"data\":{\"message\":{\"headers\":{\"subject\":\"Test Mail from java\",\"from\":\"renee@undefeatedgames.com\",\"reply-to\":null},\"bcc\":null,\"attachments\":[{\"fileName\":\"hello_world.txt\",\"contentType\":\"text/plain\",\"content\":\"SGVsbG8gV29ybGQh\\n\"}],\"allowNonTLS\":false,\"recipients\":[\"username@domain.com\"],\"content\":{\"text/html\":null,\"text/plain\":\"Hello Again\"}}}}";
 		try {
 			String response = APIHelper.callToAPIByPost(url, authToken, requestBody);
@@ -70,27 +91,30 @@ public class TestAPIHelper extends TestCase {
 
 	@Test(expected = Exception.class)
 	public void testCallToAPIByPostForAuth() {
-		String url = "https://api.paubox.net/v1/undefeatedgames/messages";
+		setParams();
+		String url = baseUrl + "/messages";
 		// token is wrong. it gives 401 error code
-		String authToken = "Token token=6f7c0110a47f82e7bff933f68cc8d7ec00";
 		String requestBody = "{\"data\":{\"message\":{\"headers\":{\"subject\":\"Test Mail from java\",\"from\":\"renee@undefeatedgames.com\",\"reply-to\":null},\"bcc\":null,\"attachments\":[{\"fileName\":\"hello_world.txt\",\"contentType\":\"text/plain\",\"content\":\"SGVsbG8gV29ybGQh\\n\"}],\"allowNonTLS\":false,\"recipients\":[\"username@domain.com\"],\"content\":{\"text/html\":null,\"text/plain\":\"Hello Again\"}}}}";
 		try {
-			String response = APIHelper.callToAPIByPost(url, authToken, requestBody);
+			String response = APIHelper.callToAPIByPost(url, "Token token=b00000964da30b000b7e00000e27a1b000000000", requestBody);
 			assertNotNull(response);
 		} catch (Exception e) {
-			e.printStackTrace();
+			// e.printStackTrace();
 		}
 	}
 
 	@Test(expected = ClientProtocolException.class)
 	public void testCallToAPIByPostForUrl() {
 		// url is mallformed.
-		String url = "https:api.paubox.net/v1/undefeatedgames/messages";
-		String authToken = "Token token=6f7c0110a47f82e7bff933f68cc8d7ec";
+		setParams();
+		String url = baseUrl + "/messages";
+		url = url.replaceFirst("//", "");
 		String requestBody = "{\"data\":{\"message\":{\"headers\":{\"subject\":\"Test Mail from java\",\"from\":\"renee@undefeatedgames.com\",\"reply-to\":null},\"bcc\":null,\"attachments\":[{\"fileName\":\"hello_world.txt\",\"contentType\":\"text/plain\",\"content\":\"SGVsbG8gV29ybGQh\\n\"}],\"allowNonTLS\":false,\"recipients\":[\"username@domain.com\"],\"content\":{\"text/html\":null,\"text/plain\":\"Hello Again\"}}}}";
 		try {
 			 APIHelper.callToAPIByPost(url, authToken, requestBody);
-		} catch (Exception e) {
+		} catch(ClientProtocolException cpe) {
+			// do nothing
+		} catch(Exception e) {
 			e.printStackTrace();
 		}
 	}
@@ -98,8 +122,8 @@ public class TestAPIHelper extends TestCase {
 	@Test
 	public void testCallToAPIByPostForOptionalValues() {
 		// removing the optional values in messsage.
-		String url = "https://api.paubox.net/v1/undefeatedgames/messages";
-		String authToken = "Token token=6f7c0110a47f82e7bff933f68cc8d7ec";
+		setParams();
+		String url = baseUrl + "/messages";
 		String requestBody = "{\"data\":{\"message\":{\"headers\":{\"subject\":\"Test Mail from java\",\"from\":\"renee@undefeatedgames.com\",\"reply-to\":null},\"bcc\":null,\"attachments\":[{\"fileName\":\"hello_world.txt\",\"contentType\":\"text/plain\",\"content\":\"SGVsbG8gV29ybGQh\\n\"}],\"recipients\":[\"username@domain.com\"],\"content\":{\"text/html\":null,\"text/plain\":\"Hello Again\"}}}}";
 		try {
 			String response = APIHelper.callToAPIByPost(url, authToken, requestBody);
@@ -109,11 +133,11 @@ public class TestAPIHelper extends TestCase {
 		}
 	}
 
-		@Test
+	@Test
 	public void testCallToAPIByPostForContent() {
 		// if content type is text plain , and text plain field is null ? 
-		String url = "https://api.paubox.net/v1/undefeatedgames/messages";
-		String authToken = "Token token=6f7c0110a47f82e7bff933f68cc8d7ec";
+		setParams();
+		String url = baseUrl + "/messages";
 		String requestBody = "{\"data\":{\"message\":{\"headers\":{\"subject\":\"Test Mail from java\",\"from\":\"renee@undefeatedgames.com\",\"reply-to\":null},\"bcc\":null,\"attachments\":[{\"fileName\":\"hello_world.txt\",\"contentType\":\"text/plain\",\"content\":\"SGVsbG8gV29ybGQh\\n\"}],\"allowNonTLS\":false,\"recipients\":[\"username@domain.com\"],\"content\":{\"text/html\":null,\"text/plain\":null}}}}";
 		try {
 			String response = APIHelper.callToAPIByPost(url, authToken, requestBody);
@@ -132,8 +156,8 @@ public class TestAPIHelper extends TestCase {
 	@Test
 	public void testCallToAPIByPostForAttachment() {
 		//  if attachment.contentType is not valid MIME type
-		String url = "https://api.paubox.net/v1/undefeatedgames/messages";
-		String authToken = "Token token=6f7c0110a47f82e7bff933f68cc8d7ec";
+		setParams();
+		String url = baseUrl + "/messages";
 		String requestBody= "{\"data\":{\"message\":{\"headers\":{\"subject\":\"Test Mail from java\",\"from\":\"renee@undefeatedgames.com\",\"reply-to\":null},\"bcc\":null,\"attachments\":[{\"fileName\":\"hello_world.txt\",\"contentType\":\"text11/html11\",\"content\":\"SGVsbG8gV29ybGQh\\n\"}],\"allowNonTLS\":false,\"recipients\":[\"username@domain.com\"],\"content\":{\"text/html\":null,\"text/plain\":\"Hello Again\"}}}}";
 		try {
 			String response = APIHelper.callToAPIByPost(url, authToken, requestBody);
@@ -146,8 +170,8 @@ public class TestAPIHelper extends TestCase {
 	@Test
 	public void testCallToAPIByPostForMandatory () {
 		// content is missing
-		String url = "https://api.paubox.net/v1/undefeatedgames/messages";
-		String authToken = "Token token=6f7c0110a47f82e7bff933f68cc8d7ec";
+		setParams();
+		String url = baseUrl + "/messages";
 		//missing header
 		String requestBody = "{\"data\":{\"message\":{\"bcc\":null,\"attachments\":[{\"fileName\":\"hello_world.txt\",\"contentType\":\"text/plain\",\"content\":\"SGVsbG8gV29ybGQh\\n\"}],\"allowNonTLS\":false,\"recipients\":[\"username@domain.com\"],\"content\":{\"text/html\":null,\"text/plain\":\"Hello Again\"}}}}";
 		try {

--- a/Paubox_Java/paubox-java/src/test/TestEmailService.java
+++ b/Paubox_Java/paubox-java/src/test/TestEmailService.java
@@ -7,6 +7,10 @@ import static org.junit.Assert.assertNull;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.nio.file.Paths;
+import java.util.Base64;
+import java.nio.file.Files;
+
 
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -24,11 +28,19 @@ import com.paubox.service.EmailService;
 
 public class TestEmailService {
 	EmailInterface email = new EmailService();
-	 Message message =new Message();
+	Message message =new Message();
+
+
 	
 	@BeforeClass
 	public static void  init(){
-		ConfigurationManager.getProperties("E:\\projects\\paubox-java\\Paubox_Java\\PauboxTest\\src\\resources\\config.properties");
+		String propertiesFile = System.getProperty("properties");
+		if (propertiesFile == null || propertiesFile.equals("")) {
+			propertiesFile = "src/test/config.properties";
+		}
+		ConfigurationManager.getProperties(propertiesFile);
+
+
 	}
 	
 	@Before

--- a/Paubox_Java/paubox-java/src/test/config.properties.sample
+++ b/Paubox_Java/paubox-java/src/test/config.properties.sample
@@ -1,0 +1,5 @@
+APIKEY=<put your API key for paubox here hexadecimal>
+APIUSER=<api user>
+BASE_URL=<microservice base URL>
+RECIPIENTS=<test@test.com where you want the email to go to >
+PDFFILE=src/test/testFile.pdf # for pdf attachment test


### PR DESCRIPTION
__ISSUE:__
 junit tests with hardcoded values
https://paubox.atlassian.net/browse/PAUB-1417

__DESCRIPTION:__
Some junit tests have the URL and auth token hardcoded, this requires the test file to be modified for running the tests, the idea is to move these parameters to a config file s that the test code need not be modified.

__STEPS TO TEST:__
Run the junit tests
DEV only, no testing from QA required

__CHANGELIST:__
src/com/paubox/config/ConfigurationManager.java
src/test/config.properties.sample
src/test/TestEmailService.java
src/test/TestAPIHelper.java