### PR TITLE
docs: update paubox.com links to current marketing URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **NEW:** [Version 2 of the Paubox Email API SDK for Java](https://github.com/Paubox/paubox-java/tree/sdk-generation/v2.0.0-beta) is available to beta test now. It includes code for newer features like bulk message sending, dynamic templates, and more. We will be deprecating the old in the near future.
 
-This is the official Java wrapper for the [Paubox Email API](https://www.paubox.com/solutions/email-api). 
+This is the official Java wrapper for the [Paubox Email API](https://www.paubox.com/products/paubox-email-api). 
 
 The Paubox Email API allows your application to send secure, HIPAA compliant email via Paubox and track deliveries and opens.
 The API wrapper allows you to construct and send messages.
@@ -22,7 +22,7 @@ Add the jar file (Paubox.Email.API.jar) in the classpath of your Java project.
 
 ### Getting Paubox API Credentials
 
-You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/join/see-pricing?unit=messages).
+You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/pricing/paubox-email-api).
 
 Once you have an account, follow the instructions on the Rest API dashboard to verify domain ownership and generate API credentials.
 


### PR DESCRIPTION
## Summary

Audited the repo for `paubox.com` / `paubox.net` references and rewrote legacy
marketing URLs to their current canonical values. The Paubox docs site moved
to Mintlify and the marketing site restructured a couple of paths; this brings
the README in line with what's actually live today.

## Inventory (3 matches total)

| # | File | Line | URL | Classification |
|---|---|---|---|---|
| 1 | `README.md` | 7 | `https://www.paubox.com/solutions/email-api` | Marketing migration → updated |
| 2 | `README.md` | 25 | `https://www.paubox.com/join/see-pricing?unit=messages` | Marketing migration → updated |
| 3 | `Paubox_Java/paubox-java/src/com/paubox/service/EmailService.java` | 18 | `https://api.paubox.net/v1/` | API endpoint, well-formed — **no change** |

No `docs.paubox.com` references exist in this repo, so the legacy Swagger-path
patterns (A/B/C in the audit brief) never triggered. `pom.xml` has no Paubox
URLs and there are no committed build-output trees.

## Counts by classification

- Marketing migration: **2** (both edited)
- API endpoint (no change): **1**
- Flagged: **0**

## Changes

```diff
-This is the official Java wrapper for the [Paubox Email API](https://www.paubox.com/solutions/email-api).
+This is the official Java wrapper for the [Paubox Email API](https://www.paubox.com/products/paubox-email-api).
```

```diff
-You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/join/see-pricing?unit=messages).
+You will need to have a Paubox account. You can [sign up here](https://www.paubox.com/pricing/paubox-email-api).
```

The `?unit=messages` query string was stripped per the audit brief's policy
("Query strings on docs URLs → strip them as part of the rewrite"), which
matches what the new `/pricing/paubox-email-api` page expects anyway.

## Liveness checks

| URL | Status | Notes |
|---|---|---|
| `https://www.paubox.com/products/paubox-email-api` | `200` | New target #1 — live |
| `https://www.paubox.com/pricing/paubox-email-api`  | `200` | New target #2 — live |
| `https://www.paubox.com/solutions/email-api` (legacy) | redirect → `/products/paubox-email-api` | Confirms migration mapping |
| `https://www.paubox.com/join/see-pricing?unit=messages` (legacy) | `404` | Confirms the fix was needed |

## Test plan

- [ ] Review the rendered README on this branch and click each updated link
- [ ] Confirm `https://www.paubox.com/products/paubox-email-api` lands on the Email API product page
- [ ] Confirm `https://www.paubox.com/pricing/paubox-email-api` lands on the Email API pricing page
- [ ] Spot-check that no other `paubox.com` / `paubox.net` references were touched: `git diff master...docs/url-cleanup -- ':!README.md'` should be empty

Leaving open for human review — do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)