### PR TITLE
Add Paubox Forms API support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Developer context for working on this SDK.
 This repo is the official Java wrapper for two Paubox APIs:
 
 - **Paubox Email API** — send HIPAA-compliant emails, check delivery status. Requires an API key and username. Base URL: `https://api.paubox.net/v1/{API_USER}/`
-- **Paubox Forms API** — retrieve form definitions and submit responses. No API key required. Base URL: `https://next.paubox.com`
+- **Paubox Forms API** — retrieve form definitions and submit responses. No API key required. Base URL: `https://apx.paubox.com/forms`
 
 ## Project Layout
 

--- a/Paubox_Java/paubox-java/src/com/paubox/common/Constants.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/common/Constants.java
@@ -10,5 +10,5 @@ public class Constants {
 	
 	public  final static  int HTTP_STATUS_SUCCESS = 200;
 
-	public  final static  String FORMS_BASE_URL = "https://next.paubox.com";
+	public  final static  String FORMS_BASE_URL = "https://apx.paubox.com/forms";
 }

--- a/Paubox_Java/paubox-java/src/com/paubox/service/FormsService.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/service/FormsService.java
@@ -8,7 +8,7 @@ import com.paubox.data.FormSubmissionRequest;
 
 public class FormsService implements FormsInterface {
 
-    private static final String FORMS_BASE_URL = "https://next.paubox.com";
+    private static final String FORMS_BASE_URL = "https://apx.paubox.com/forms";
 
     public Form getForm(String formId) throws Exception {
         String url = FORMS_BASE_URL + "/public/form_data/" + formId;

--- a/api.md
+++ b/api.md
@@ -111,7 +111,7 @@ GetEmailDispositionResponse response = email.getEmailDisposition(sourceTrackingI
 
 ## Forms API
 
-Base URL: `https://next.paubox.com`  
+Base URL: `https://apx.paubox.com/forms`  
 Authentication: **None required**
 
 ### Setup


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Implements both public Paubox Forms endpoints (`GET /public/form_data/{id}` and `POST /api/forms/{id}/submissions`) against `https://apx.paubox.com/forms` — no API key required
- Adds `Form`, `FormSubmissionRequest`, and `FormSubmissionAttachment` data models, plus `FormsInterface` and `FormsService`
- Adds `APIHelper.callToAPIByPostReturnCode` to handle 201 empty-body responses without breaking existing callers
- Creates `CLAUDE.md` (developer guide) and `api.md` (full API reference), and extends `README.md` with Forms usage examples and code snippets
- Updates `Constants.FORMS_BASE_URL` to the new `https://apx.paubox.com/forms` host

## Test plan

- [ ] `mvn compile -f Paubox_Java/paubox-java/pom.xml` passes cleanly
- [ ] `mvn test -f Paubox_Java/paubox-java/pom.xml -Dproperties=...` — existing email tests unaffected
- [ ] With a real `FORM_ID` in config, `TestFormsService` passes all six test cases
- [ ] Manually call `new FormsService().getForm(formId)` and confirm the `Form` fields populate correctly
- [ ] Manually call `submitForm(formId, submission)` and confirm 201 is returned with no exception

https://claude.ai/code/session_019Jbub6LvEqAFLfMwbeR1CP
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_019Jbub6LvEqAFLfMwbeR1CP)_