### PR TITLE
Add authenticated Forms management endpoints with scoped API key support

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,7 +7,7 @@ Developer context for working on this SDK.
 This repo is the official Java wrapper for two Paubox APIs:
 
 - **Paubox Email API** — send HIPAA-compliant emails, check delivery status. Requires an API key and username. Base URL: `https://api.paubox.net/v1/{API_USER}/`
-- **Paubox Forms API** — retrieve form definitions and submit responses. No API key required. Base URL: `https://apx.paubox.com/forms`
+- **Paubox Forms API** — retrieve form definitions, submit responses, and manage forms/submissions. Public respondent endpoints (get public form data, submit) need no key; management endpoints (list/create/update/archive/copy forms, stats, submissions, CSV/PDF export) need a scoped API key with the `forms` scope. Base URL: `https://apx.paubox.com/forms`
 
 ## Project Layout
 
@@ -58,11 +58,15 @@ RECIPIENTS=recipient@example.com
 PDFFILE=src/test/testFile.pdf
 ```
 
-Additional property for forms tests:
+Additional properties for forms tests:
 
 ```
 FORM_ID=550e8400-e29b-41d4-a716-446655440000
+FORMSAPIKEY=scoped-api-key-with-forms-scope
+CUSTOMER_ID=12345
 ```
+
+`FORM_ID` is used by the public and submission-listing tests, `FORMSAPIKEY` by all forms management tests (they skip when it's absent), and `CUSTOMER_ID` by the form create/update lifecycle test.
 
 ## Architecture Patterns
 
@@ -70,7 +74,10 @@ FORM_ID=550e8400-e29b-41d4-a716-446655440000
 `EmailService` passes `"Token token=" + Constants.API_KEY` as the `Authorization` header via `APIHelper.callToAPIByGet` / `callToAPIByPost`. Responses are JSON — deserialize with Jackson `ObjectMapper` using `FAIL_ON_UNKNOWN_PROPERTIES = false`.
 
 ### Public endpoints (Forms API)
-`FormsService` passes `null` for the auth header (already handled by `APIHelper`). The submit endpoint returns HTTP 201 with an empty body, so it uses `APIHelper.callToAPIByPostReturnCode` which returns the status code as an int instead of the body string.
+For the respondent endpoints (`getForm`, `submitForm`), `FormsService` passes `null` for the auth header (already handled by `APIHelper`). The submit endpoint returns HTTP 201 with an empty body, so it uses `APIHelper.callToAPIByPostReturnCode` which returns the status code as an int instead of the body string.
+
+### Scoped-key endpoints (Forms API management)
+All other Forms methods pass `"Bearer " + apiKey` as the `Authorization` header. The key is a scoped API key with the `forms` scope, held in a `private final String apiKey` field on `FormsService`: `new FormsService(String apiKey)` sets it explicitly, and the no-arg constructor falls back to `Constants.FORMS_API_KEY` (loaded by `ConfigurationManager` from the `FORMSAPIKEY` property). A missing key only fails when an authenticated method is called. Binary exports (CSV/PDF) use `APIHelper.callToAPIByGetBytes`, which returns `byte[]`; `updateForm` uses `APIHelper.callToAPIByPut`.
 
 ### Adding a new endpoint
 1. Add a response DTO in `src/com/paubox/data/` — use `@JsonProperty` for snake_case fields.

--- a/Paubox_Java/paubox-java/src/com/paubox/common/Constants.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/common/Constants.java
@@ -3,6 +3,7 @@ package com.paubox.common;
 public class Constants {
 
 	public static String API_KEY;
+	public static String FORMS_API_KEY;
 	public  static String API_USER;
 	
 	public  final static  String TYPE_GET="GET";

--- a/Paubox_Java/paubox-java/src/com/paubox/config/ConfigurationManager.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/config/ConfigurationManager.java
@@ -32,6 +32,7 @@ public class ConfigurationManager {
 		
 		Constants.API_KEY=properties.getProperty("APIKEY");
 		Constants.API_USER=properties.getProperty("APIUSER");
+		Constants.FORMS_API_KEY = properties.getProperty("FORMSAPIKEY");
 		
 	}
 

--- a/Paubox_Java/paubox-java/src/com/paubox/data/CopyFormRequest.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/data/CopyFormRequest.java
@@ -1,0 +1,27 @@
+package com.paubox.data;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CopyFormRequest {
+
+    @JsonProperty("form_id")
+    private String formId;
+
+    private String title;
+
+    public CopyFormRequest() {
+    }
+
+    public CopyFormRequest(String formId, String title) {
+        this.formId = formId;
+        this.title = title;
+    }
+
+    public String getFormId() { return formId; }
+    public void setFormId(String formId) { this.formId = formId; }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+}

--- a/Paubox_Java/paubox-java/src/com/paubox/data/CreateFormRequest.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/data/CreateFormRequest.java
@@ -1,0 +1,93 @@
+package com.paubox.data;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class CreateFormRequest {
+
+    private String title;
+    private String description;
+
+    @JsonProperty("form_html")
+    private String formHtml;
+
+    @JsonProperty("form_json")
+    private Object formJson;
+
+    @JsonProperty("form_css")
+    private String formCss;
+
+    @JsonProperty("customer_id")
+    private Integer customerId;
+
+    private String recipient;
+    private Boolean signable;
+
+    @JsonProperty("signature_confirmation_label")
+    private String signatureConfirmationLabel;
+
+    @JsonProperty("subscription_list_id")
+    private String subscriptionListId;
+
+    private String type;
+    private Boolean active;
+    private Integer version;
+
+    @JsonProperty("submission_count")
+    private Integer submissionCount;
+
+    public CreateFormRequest() {
+    }
+
+    public CreateFormRequest(String title, Object formJson, Integer customerId, Integer version) {
+        this.title = title;
+        this.formJson = formJson;
+        this.customerId = customerId;
+        this.version = version;
+    }
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public String getFormHtml() { return formHtml; }
+    public void setFormHtml(String formHtml) { this.formHtml = formHtml; }
+
+    public Object getFormJson() { return formJson; }
+    public void setFormJson(Object formJson) { this.formJson = formJson; }
+
+    public String getFormCss() { return formCss; }
+    public void setFormCss(String formCss) { this.formCss = formCss; }
+
+    public Integer getCustomerId() { return customerId; }
+    public void setCustomerId(Integer customerId) { this.customerId = customerId; }
+
+    public String getRecipient() { return recipient; }
+    public void setRecipient(String recipient) { this.recipient = recipient; }
+
+    public Boolean getSignable() { return signable; }
+    public void setSignable(Boolean signable) { this.signable = signable; }
+
+    public String getSignatureConfirmationLabel() { return signatureConfirmationLabel; }
+    public void setSignatureConfirmationLabel(String signatureConfirmationLabel) {
+        this.signatureConfirmationLabel = signatureConfirmationLabel;
+    }
+
+    public String getSubscriptionListId() { return subscriptionListId; }
+    public void setSubscriptionListId(String subscriptionListId) { this.subscriptionListId = subscriptionListId; }
+
+    public String getType() { return type; }
+    public void setType(String type) { this.type = type; }
+
+    public Boolean getActive() { return active; }
+    public void setActive(Boolean active) { this.active = active; }
+
+    public Integer getVersion() { return version; }
+    public void setVersion(Integer version) { this.version = version; }
+
+    public Integer getSubmissionCount() { return submissionCount; }
+    public void setSubmissionCount(Integer submissionCount) { this.submissionCount = submissionCount; }
+}

--- a/Paubox_Java/paubox-java/src/com/paubox/data/CreateFormResponse.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/data/CreateFormResponse.java
@@ -1,0 +1,9 @@
+package com.paubox.data;
+
+public class CreateFormResponse {
+
+    private String id;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+}

--- a/Paubox_Java/paubox-java/src/com/paubox/data/Form.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/data/Form.java
@@ -20,16 +20,24 @@ public class Form {
     @JsonProperty("vanity_url")
     private String vanityUrl;
 
+    @JsonProperty("old_form_id")
+    private Integer oldFormId;
+
     private int version;
     private boolean active;
 
     @JsonProperty("customer_id")
     private int customerId;
 
+    private String recipient;
+
     private boolean signable;
 
     @JsonProperty("signature_confirmation_label")
     private String signatureConfirmationLabel;
+
+    @JsonProperty("subscription_list_id")
+    private String subscriptionListId;
 
     @JsonProperty("submission_count")
     private int submissionCount;
@@ -65,6 +73,9 @@ public class Form {
     public String getVanityUrl() { return vanityUrl; }
     public void setVanityUrl(String vanityUrl) { this.vanityUrl = vanityUrl; }
 
+    public Integer getOldFormId() { return oldFormId; }
+    public void setOldFormId(Integer oldFormId) { this.oldFormId = oldFormId; }
+
     public int getVersion() { return version; }
     public void setVersion(int version) { this.version = version; }
 
@@ -74,12 +85,20 @@ public class Form {
     public int getCustomerId() { return customerId; }
     public void setCustomerId(int customerId) { this.customerId = customerId; }
 
+    public String getRecipient() { return recipient; }
+    public void setRecipient(String recipient) { this.recipient = recipient; }
+
     public boolean isSignable() { return signable; }
     public void setSignable(boolean signable) { this.signable = signable; }
 
     public String getSignatureConfirmationLabel() { return signatureConfirmationLabel; }
     public void setSignatureConfirmationLabel(String signatureConfirmationLabel) {
         this.signatureConfirmationLabel = signatureConfirmationLabel;
+    }
+
+    public String getSubscriptionListId() { return subscriptionListId; }
+    public void setSubscriptionListId(String subscriptionListId) {
+        this.subscriptionListId = subscriptionListId;
     }
 
     public int getSubmissionCount() { return submissionCount; }

--- a/Paubox_Java/paubox-java/src/com/paubox/data/FormListRequest.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/data/FormListRequest.java
@@ -1,0 +1,48 @@
+package com.paubox.data;
+
+/**
+ * Query-parameter holder for listing forms. This object is never JSON-serialized;
+ * its fields are appended to the request URL as query parameters. Null fields are omitted.
+ */
+public class FormListRequest {
+
+    private Integer customerId;
+    private String formId;
+    private String search;
+    private String order;
+    private String orderBy;
+    private Boolean archived;
+    private Boolean active;
+    private Integer page;
+    private Integer items;
+
+    public FormListRequest() {
+    }
+
+    public Integer getCustomerId() { return customerId; }
+    public void setCustomerId(Integer customerId) { this.customerId = customerId; }
+
+    public String getFormId() { return formId; }
+    public void setFormId(String formId) { this.formId = formId; }
+
+    public String getSearch() { return search; }
+    public void setSearch(String search) { this.search = search; }
+
+    public String getOrder() { return order; }
+    public void setOrder(String order) { this.order = order; }
+
+    public String getOrderBy() { return orderBy; }
+    public void setOrderBy(String orderBy) { this.orderBy = orderBy; }
+
+    public Boolean getArchived() { return archived; }
+    public void setArchived(Boolean archived) { this.archived = archived; }
+
+    public Boolean getActive() { return active; }
+    public void setActive(Boolean active) { this.active = active; }
+
+    public Integer getPage() { return page; }
+    public void setPage(Integer page) { this.page = page; }
+
+    public Integer getItems() { return items; }
+    public void setItems(Integer items) { this.items = items; }
+}

--- a/Paubox_Java/paubox-java/src/com/paubox/data/FormListResponse.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/data/FormListResponse.java
@@ -1,0 +1,19 @@
+package com.paubox.data;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class FormListResponse {
+
+    private List<Form> results;
+
+    @JsonProperty("page_info")
+    private PageInfo pageInfo;
+
+    public List<Form> getResults() { return results; }
+    public void setResults(List<Form> results) { this.results = results; }
+
+    public PageInfo getPageInfo() { return pageInfo; }
+    public void setPageInfo(PageInfo pageInfo) { this.pageInfo = pageInfo; }
+}

--- a/Paubox_Java/paubox-java/src/com/paubox/data/FormResponse.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/data/FormResponse.java
@@ -1,0 +1,9 @@
+package com.paubox.data;
+
+public class FormResponse {
+
+    private Form data;
+
+    public Form getData() { return data; }
+    public void setData(Form data) { this.data = data; }
+}

--- a/Paubox_Java/paubox-java/src/com/paubox/data/FormStats.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/data/FormStats.java
@@ -1,0 +1,24 @@
+package com.paubox.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class FormStats {
+
+    @JsonProperty("active_form_count")
+    private long activeFormCount;
+
+    @JsonProperty("total_submission_count")
+    private long totalSubmissionCount;
+
+    @JsonProperty("submissions_last_7_days")
+    private long submissionsLast7Days;
+
+    public long getActiveFormCount() { return activeFormCount; }
+    public void setActiveFormCount(long activeFormCount) { this.activeFormCount = activeFormCount; }
+
+    public long getTotalSubmissionCount() { return totalSubmissionCount; }
+    public void setTotalSubmissionCount(long totalSubmissionCount) { this.totalSubmissionCount = totalSubmissionCount; }
+
+    public long getSubmissionsLast7Days() { return submissionsLast7Days; }
+    public void setSubmissionsLast7Days(long submissionsLast7Days) { this.submissionsLast7Days = submissionsLast7Days; }
+}

--- a/Paubox_Java/paubox-java/src/com/paubox/data/FormSubmission.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/data/FormSubmission.java
@@ -1,0 +1,81 @@
+package com.paubox.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class FormSubmission {
+
+    private String id;
+
+    @JsonProperty("form_id")
+    private String formId;
+
+    @JsonProperty("form_data")
+    private String formData;
+
+    @JsonProperty("storage_type")
+    private String storageType;
+
+    @JsonProperty("storage_url")
+    private String storageUrl;
+
+    @JsonProperty("submitter_email")
+    private String submitterEmail;
+
+    private String recipients;
+
+    private String attachment;
+
+    @JsonProperty("attachment_name")
+    private String attachmentName;
+
+    @JsonProperty("attachment_url")
+    private String attachmentUrl;
+
+    @JsonProperty("attachment_type")
+    private String attachmentType;
+
+    @JsonProperty("created_at")
+    private String createdAt;
+
+    public String getId() { return id; }
+    public void setId(String id) { this.id = id; }
+
+    public String getFormId() { return formId; }
+    public void setFormId(String formId) { this.formId = formId; }
+
+    public String getFormData() { return formData; }
+    public void setFormData(String formData) { this.formData = formData; }
+
+    public String getStorageType() { return storageType; }
+    public void setStorageType(String storageType) { this.storageType = storageType; }
+
+    public String getStorageUrl() { return storageUrl; }
+    public void setStorageUrl(String storageUrl) { this.storageUrl = storageUrl; }
+
+    public String getSubmitterEmail() { return submitterEmail; }
+    public void setSubmitterEmail(String submitterEmail) { this.submitterEmail = submitterEmail; }
+
+    public String getRecipients() { return recipients; }
+    public void setRecipients(String recipients) { this.recipients = recipients; }
+
+    public String getAttachment() { return attachment; }
+    public void setAttachment(String attachment) { this.attachment = attachment; }
+
+    public String getAttachmentName() { return attachmentName; }
+    public void setAttachmentName(String attachmentName) { this.attachmentName = attachmentName; }
+
+    public String getAttachmentUrl() { return attachmentUrl; }
+    public void setAttachmentUrl(String attachmentUrl) { this.attachmentUrl = attachmentUrl; }
+
+    public String getAttachmentType() { return attachmentType; }
+    public void setAttachmentType(String attachmentType) { this.attachmentType = attachmentType; }
+
+    public String getCreatedAt() { return createdAt; }
+    public void setCreatedAt(String createdAt) { this.createdAt = createdAt; }
+
+    @Override
+    public String toString() {
+        return "FormSubmission [id=" + id + ", formId=" + formId
+                + ", submitterEmail=" + submitterEmail + ", createdAt=" + createdAt + "]";
+    }
+}

--- a/Paubox_Java/paubox-java/src/com/paubox/data/FormSubmissionListRequest.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/data/FormSubmissionListRequest.java
@@ -1,0 +1,33 @@
+package com.paubox.data;
+
+/**
+ * Query-parameter holder for listing form submissions. This class is never
+ * serialized to JSON; its fields become URL query parameters. Null fields are
+ * omitted so the API defaults apply.
+ */
+public class FormSubmissionListRequest {
+
+    private String submissionId;
+    private String order;
+    private String orderBy;
+    private Integer page;
+    private Integer items;
+
+    public FormSubmissionListRequest() {
+    }
+
+    public String getSubmissionId() { return submissionId; }
+    public void setSubmissionId(String submissionId) { this.submissionId = submissionId; }
+
+    public String getOrder() { return order; }
+    public void setOrder(String order) { this.order = order; }
+
+    public String getOrderBy() { return orderBy; }
+    public void setOrderBy(String orderBy) { this.orderBy = orderBy; }
+
+    public Integer getPage() { return page; }
+    public void setPage(Integer page) { this.page = page; }
+
+    public Integer getItems() { return items; }
+    public void setItems(Integer items) { this.items = items; }
+}

--- a/Paubox_Java/paubox-java/src/com/paubox/data/FormSubmissionListResponse.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/data/FormSubmissionListResponse.java
@@ -1,0 +1,28 @@
+package com.paubox.data;
+
+import java.util.List;
+
+public class FormSubmissionListResponse {
+
+    private List<FormSubmission> data;
+    private long total;
+    private int page;
+    private int items;
+
+    public List<FormSubmission> getData() { return data; }
+    public void setData(List<FormSubmission> data) { this.data = data; }
+
+    public long getTotal() { return total; }
+    public void setTotal(long total) { this.total = total; }
+
+    public int getPage() { return page; }
+    public void setPage(int page) { this.page = page; }
+
+    public int getItems() { return items; }
+    public void setItems(int items) { this.items = items; }
+
+    @Override
+    public String toString() {
+        return "FormSubmissionListResponse [total=" + total + ", page=" + page + ", items=" + items + "]";
+    }
+}

--- a/Paubox_Java/paubox-java/src/com/paubox/data/PageInfo.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/data/PageInfo.java
@@ -1,0 +1,21 @@
+package com.paubox.data;
+
+public class PageInfo {
+
+    private long count;
+    private int pages;
+    private int page;
+    private int items;
+
+    public long getCount() { return count; }
+    public void setCount(long count) { this.count = count; }
+
+    public int getPages() { return pages; }
+    public void setPages(int pages) { this.pages = pages; }
+
+    public int getPage() { return page; }
+    public void setPage(int page) { this.page = page; }
+
+    public int getItems() { return items; }
+    public void setItems(int items) { this.items = items; }
+}

--- a/Paubox_Java/paubox-java/src/com/paubox/data/UpdateFormRequest.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/data/UpdateFormRequest.java
@@ -1,0 +1,48 @@
+package com.paubox.data;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Request body for updating a form. Update semantics are PATCH-like:
+ * a null field is omitted from the request and the form's value stays unchanged.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class UpdateFormRequest {
+
+    private String title;
+    private String description;
+
+    @JsonProperty("form_json")
+    private Object formJson;
+
+    @JsonProperty("vanity_url")
+    private String vanityUrl;
+
+    private String recipient;
+    private Boolean active;
+
+    @JsonProperty("subscription_list_id")
+    private String subscriptionListId;
+
+    public String getTitle() { return title; }
+    public void setTitle(String title) { this.title = title; }
+
+    public String getDescription() { return description; }
+    public void setDescription(String description) { this.description = description; }
+
+    public Object getFormJson() { return formJson; }
+    public void setFormJson(Object formJson) { this.formJson = formJson; }
+
+    public String getVanityUrl() { return vanityUrl; }
+    public void setVanityUrl(String vanityUrl) { this.vanityUrl = vanityUrl; }
+
+    public String getRecipient() { return recipient; }
+    public void setRecipient(String recipient) { this.recipient = recipient; }
+
+    public Boolean getActive() { return active; }
+    public void setActive(Boolean active) { this.active = active; }
+
+    public String getSubscriptionListId() { return subscriptionListId; }
+    public void setSubscriptionListId(String subscriptionListId) { this.subscriptionListId = subscriptionListId; }
+}

--- a/Paubox_Java/paubox-java/src/com/paubox/data/UpdateFormResponse.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/data/UpdateFormResponse.java
@@ -1,0 +1,21 @@
+package com.paubox.data;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * Response for form update. Also reused for archive/unarchive responses,
+ * where formId stays null.
+ */
+public class UpdateFormResponse {
+
+    private String detail;
+
+    @JsonProperty("form_id")
+    private String formId;
+
+    public String getDetail() { return detail; }
+    public void setDetail(String detail) { this.detail = detail; }
+
+    public String getFormId() { return formId; }
+    public void setFormId(String formId) { this.formId = formId; }
+}

--- a/Paubox_Java/paubox-java/src/com/paubox/service/APIHelper.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/service/APIHelper.java
@@ -10,11 +10,24 @@ import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
+import org.apache.http.client.params.ClientPNames;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.params.CoreConnectionPNames;
 import org.apache.http.util.EntityUtils;
 
 public class APIHelper {
+
+	private static final int CONNECT_TIMEOUT_MS = 30000;
+	private static final int SOCKET_TIMEOUT_MS = 30000;
+
+	private static DefaultHttpClient newClient() {
+		DefaultHttpClient httpClient = new DefaultHttpClient();
+		httpClient.getParams().setParameter(CoreConnectionPNames.CONNECTION_TIMEOUT, CONNECT_TIMEOUT_MS);
+		httpClient.getParams().setParameter(CoreConnectionPNames.SO_TIMEOUT, SOCKET_TIMEOUT_MS);
+		httpClient.getParams().setParameter(ClientPNames.HANDLE_REDIRECTS, Boolean.FALSE);
+		return httpClient;
+	}
 	
 	/**
 	 * Call http get API
@@ -25,7 +38,7 @@ public class APIHelper {
 	 */
 	public static String callToAPIByGet(String baseAPIUrl, String authHeader) throws Exception {
 		try {
-			DefaultHttpClient httpClient = new DefaultHttpClient();
+			DefaultHttpClient httpClient = newClient();
 			
 			HttpGet getRequest = new HttpGet(baseAPIUrl);			
 			getRequest.addHeader("accept", "application/json");
@@ -77,7 +90,7 @@ public class APIHelper {
 	public  static String callToAPIByPost(String baseAPIUrl, String authHeader, String requestBody) throws Exception {
 		 try {
 
-				DefaultHttpClient httpClient = new DefaultHttpClient();
+				DefaultHttpClient httpClient = newClient();
 				HttpPost postRequest = new HttpPost(baseAPIUrl);
 
 				StringEntity input = new StringEntity(requestBody);
@@ -115,7 +128,7 @@ public class APIHelper {
  */
 	public static int callToAPIByPostReturnCode(String baseAPIUrl, String authHeader, String requestBody) throws Exception {
 		try {
-			DefaultHttpClient httpClient = new DefaultHttpClient();
+			DefaultHttpClient httpClient = newClient();
 			HttpPost postRequest = new HttpPost(baseAPIUrl);
 
 			StringEntity input = new StringEntity(requestBody);
@@ -147,7 +160,7 @@ public class APIHelper {
 	public static String callToAPIByPut(String baseAPIUrl, String authHeader, String requestBody) throws Exception {
 		try {
 
-			DefaultHttpClient httpClient = new DefaultHttpClient();
+			DefaultHttpClient httpClient = newClient();
 			HttpPut putRequest = new HttpPut(baseAPIUrl);
 
 			StringEntity input = new StringEntity(requestBody);
@@ -179,7 +192,7 @@ public class APIHelper {
  */
 	public static byte[] callToAPIByGetBytes(String baseAPIUrl, String authHeader) throws Exception {
 		try {
-			DefaultHttpClient httpClient = new DefaultHttpClient();
+			DefaultHttpClient httpClient = newClient();
 
 			HttpGet getRequest = new HttpGet(baseAPIUrl);
 			getRequest.addHeader("accept", "*/*");

--- a/Paubox_Java/paubox-java/src/com/paubox/service/APIHelper.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/service/APIHelper.java
@@ -9,8 +9,10 @@ import org.apache.http.HttpResponse;
 import org.apache.http.client.ClientProtocolException;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpPut;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.impl.client.DefaultHttpClient;
+import org.apache.http.util.EntityUtils;
 
 public class APIHelper {
 	
@@ -128,6 +130,72 @@ public class APIHelper {
 			return response.getStatusLine().getStatusCode();
 
 		} catch (MalformedURLException e) {
+			throw new Exception(e);
+		} catch (IOException e) {
+			throw new Exception(e);
+		}
+	}
+
+/**
+ * Call http PUT API
+ * @param baseAPIUrl String
+ * @param authHeader String
+ * @param requestBody String
+ * @return String
+ * @throws Exception
+ */
+	public static String callToAPIByPut(String baseAPIUrl, String authHeader, String requestBody) throws Exception {
+		try {
+
+			DefaultHttpClient httpClient = new DefaultHttpClient();
+			HttpPut putRequest = new HttpPut(baseAPIUrl);
+
+			StringEntity input = new StringEntity(requestBody);
+			input.setContentType("application/json");
+			putRequest.setEntity(input);
+
+			if (null != authHeader) {
+				putRequest.addHeader("Authorization", authHeader);
+			}
+
+			HttpResponse response = httpClient.execute(putRequest);
+
+			return processApiResponse(response);
+
+		} catch (MalformedURLException e) {
+			throw new Exception(e);
+		} catch (IOException e) {
+			throw new Exception(e);
+		}
+	}
+
+/**
+ * Call http GET API and return the raw response body bytes.
+ * Use for binary responses (e.g. CSV or PDF downloads).
+ * @param baseAPIUrl String
+ * @param authHeader String
+ * @return byte[] response body
+ * @throws Exception
+ */
+	public static byte[] callToAPIByGetBytes(String baseAPIUrl, String authHeader) throws Exception {
+		try {
+			DefaultHttpClient httpClient = new DefaultHttpClient();
+
+			HttpGet getRequest = new HttpGet(baseAPIUrl);
+			getRequest.addHeader("accept", "*/*");
+
+			if (null != authHeader) {
+				getRequest.addHeader("Authorization", authHeader);
+			}
+
+			HttpResponse response = httpClient.execute(getRequest);
+			int code = response.getStatusLine().getStatusCode();
+			if (code != 200) {
+				throw new Exception("Unexpected response code: " + code);
+			}
+			return EntityUtils.toByteArray(response.getEntity());
+
+		} catch (ClientProtocolException e) {
 			throw new Exception(e);
 		} catch (IOException e) {
 			throw new Exception(e);

--- a/Paubox_Java/paubox-java/src/com/paubox/service/FormsInterface.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/service/FormsInterface.java
@@ -1,7 +1,15 @@
 package com.paubox.service;
 
 import com.paubox.data.Form;
+import com.paubox.data.CreateFormRequest;
+import com.paubox.data.FormListRequest;
+import com.paubox.data.FormListResponse;
+import com.paubox.data.FormStats;
+import com.paubox.data.FormSubmissionListRequest;
+import com.paubox.data.FormSubmissionListResponse;
 import com.paubox.data.FormSubmissionRequest;
+import com.paubox.data.UpdateFormRequest;
+import com.paubox.data.UpdateFormResponse;
 
 public interface FormsInterface {
 
@@ -18,4 +26,106 @@ public interface FormsInterface {
      * @throws Exception
      */
     public void submitForm(String formId, FormSubmissionRequest submission) throws Exception;
+
+    /**
+     * List forms. Requires a scoped API key with the forms scope.
+     * When authenticating with a scoped API key, the query's customerId must be set to the
+     * API key's customer id; omitting it results in a 403 Forbidden from the API.
+     * @param query FormListRequest with optional filters and pagination; customerId is required
+     *              when authenticating with a scoped API key
+     * @return FormListResponse
+     * @throws Exception
+     */
+    public FormListResponse listForms(FormListRequest query) throws Exception;
+
+    /**
+     * Create a form. Requires a scoped API key with the forms scope.
+     * @param request CreateFormRequest with at least title, form_json, customer_id and version
+     * @return String id of the new form
+     * @throws Exception
+     */
+    public String createForm(CreateFormRequest request) throws Exception;
+
+    /**
+     * Retrieve a form regardless of active/archived state. Requires a scoped API key with the forms scope.
+     * @param formId UUID of the form to retrieve
+     * @return Form
+     * @throws Exception
+     */
+    public Form getFormById(String formId) throws Exception;
+
+    /**
+     * Update a form; null fields in the request are left unchanged. Requires a scoped API key with the forms scope.
+     * @param formId UUID of the form to update
+     * @param request UpdateFormRequest with the fields to change
+     * @return UpdateFormResponse
+     * @throws Exception
+     */
+    public UpdateFormResponse updateForm(String formId, UpdateFormRequest request) throws Exception;
+
+    /**
+     * Archive a form. Requires a scoped API key with the forms scope.
+     * @param formId UUID of the form to archive
+     * @throws Exception
+     */
+    public void archiveForm(String formId) throws Exception;
+
+    /**
+     * Unarchive a form. Requires a scoped API key with the forms scope.
+     * @param formId UUID of the form to unarchive
+     * @throws Exception
+     */
+    public void unarchiveForm(String formId) throws Exception;
+
+    /**
+     * Copy an existing form under a new title. Requires a scoped API key with the forms scope.
+     * @param formId UUID of the form to copy
+     * @param newTitle title for the copied form
+     * @return Form the newly created copy
+     * @throws Exception
+     */
+    public Form copyForm(String formId, String newTitle) throws Exception;
+
+    /**
+     * Retrieve form statistics. Requires a scoped API key with the forms scope.
+     * @param customerId optional customer id; may be null to use the API key's customer
+     * @return FormStats
+     * @throws Exception
+     */
+    public FormStats getFormStats(Integer customerId) throws Exception;
+
+    /**
+     * List submissions for a form. Requires a scoped API key with the forms scope.
+     * @param formId UUID of the form
+     * @param query FormSubmissionListRequest with optional filters and pagination; may be null for all defaults
+     * @return FormSubmissionListResponse
+     * @throws Exception
+     */
+    public FormSubmissionListResponse listFormSubmissions(String formId, FormSubmissionListRequest query) throws Exception;
+
+    /**
+     * Download all submissions of a form as CSV. Requires a scoped API key with the forms scope.
+     * @param formId UUID of the form
+     * @return byte[] CSV content
+     * @throws Exception
+     */
+    public byte[] downloadSubmissionsCsv(String formId) throws Exception;
+
+    /**
+     * Download a single submission as CSV. Requires a scoped API key with the forms scope.
+     * @param formId UUID of the form
+     * @param submissionId UUID of the submission
+     * @return byte[] CSV content
+     * @throws Exception
+     */
+    public byte[] downloadSubmissionCsv(String formId, String submissionId) throws Exception;
+
+    /**
+     * Download a single submission as PDF. Requires a scoped API key with the forms scope.
+     * @param formId UUID of the form
+     * @param submissionId UUID of the submission
+     * @return byte[] PDF content
+     * @throws Exception
+     */
+    public byte[] downloadSubmissionPdf(String formId, String submissionId) throws Exception;
 }

--- a/Paubox_Java/paubox-java/src/com/paubox/service/FormsService.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/service/FormsService.java
@@ -2,6 +2,7 @@ package com.paubox.service;
 
 import java.io.IOException;
 import java.net.URLEncoder;
+import java.util.regex.Pattern;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.paubox.common.Constants;
@@ -22,6 +23,7 @@ import com.paubox.data.UpdateFormResponse;
 public class FormsService implements FormsInterface {
 
     private static final String FORMS_BASE_URL = "https://apx.paubox.com/forms";
+    private static final Pattern UUID_PATTERN = Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
 
     private final String apiKey;
 
@@ -107,7 +109,7 @@ public class FormsService implements FormsInterface {
     }
 
     public Form getFormById(String formId) throws Exception {
-        validateId(formId, "formId");
+        validateUuid(formId, "formId");
         String url = FORMS_BASE_URL + "/api/forms/" + formId;
         String responseStr = APIHelper.callToAPIByGet(url, authHeader());
         ObjectMapper mapper = new ObjectMapper();
@@ -120,7 +122,7 @@ public class FormsService implements FormsInterface {
     }
 
     public UpdateFormResponse updateForm(String formId, UpdateFormRequest request) throws Exception {
-        validateId(formId, "formId");
+        validateUuid(formId, "formId");
         if (request == null) {
             throw new Exception("UpdateFormRequest cannot be null.");
         }
@@ -137,13 +139,13 @@ public class FormsService implements FormsInterface {
     }
 
     public void archiveForm(String formId) throws Exception {
-        validateId(formId, "formId");
+        validateUuid(formId, "formId");
         String url = FORMS_BASE_URL + "/api/forms/" + formId + "/archive";
         postWithoutBody(url);
     }
 
     public void unarchiveForm(String formId) throws Exception {
-        validateId(formId, "formId");
+        validateUuid(formId, "formId");
         String url = FORMS_BASE_URL + "/api/forms/" + formId + "/unarchive";
         postWithoutBody(url);
     }
@@ -180,7 +182,7 @@ public class FormsService implements FormsInterface {
     }
 
     public FormSubmissionListResponse listFormSubmissions(String formId, FormSubmissionListRequest query) throws Exception {
-        validateId(formId, "formId");
+        validateUuid(formId, "formId");
         StringBuilder queryString = new StringBuilder();
         if (query != null) {
             appendParam(queryString, "submission_id", query.getSubmissionId());
@@ -201,21 +203,21 @@ public class FormsService implements FormsInterface {
     }
 
     public byte[] downloadSubmissionsCsv(String formId) throws Exception {
-        validateId(formId, "formId");
+        validateUuid(formId, "formId");
         String url = FORMS_BASE_URL + "/api/forms/" + formId + "/submissions/submission-csv";
         return APIHelper.callToAPIByGetBytes(url, authHeader());
     }
 
     public byte[] downloadSubmissionCsv(String formId, String submissionId) throws Exception {
-        validateId(formId, "formId");
-        validateId(submissionId, "submissionId");
+        validateUuid(formId, "formId");
+        validateUuid(submissionId, "submissionId");
         String url = FORMS_BASE_URL + "/api/forms/" + formId + "/submissions/submission-csv/" + submissionId;
         return APIHelper.callToAPIByGetBytes(url, authHeader());
     }
 
     public byte[] downloadSubmissionPdf(String formId, String submissionId) throws Exception {
-        validateId(formId, "formId");
-        validateId(submissionId, "submissionId");
+        validateUuid(formId, "formId");
+        validateUuid(submissionId, "submissionId");
         String url = FORMS_BASE_URL + "/api/forms/" + formId + "/submissions/" + submissionId + "/submission-pdf";
         return APIHelper.callToAPIByGetBytes(url, authHeader());
     }
@@ -241,6 +243,15 @@ public class FormsService implements FormsInterface {
     private static void validateId(String value, String name) throws Exception {
         if (value == null || value.isEmpty()) {
             throw new Exception(name + " cannot be null or empty.");
+        }
+    }
+
+    private static void validateUuid(String value, String name) throws Exception {
+        if (value == null || value.isEmpty()) {
+            throw new Exception(name + " cannot be null or empty.");
+        }
+        if (!UUID_PATTERN.matcher(value).matches()) {
+            throw new Exception(name + " must be a valid UUID (8-4-4-4-12 hex).");
         }
     }
 

--- a/Paubox_Java/paubox-java/src/com/paubox/service/FormsService.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/service/FormsService.java
@@ -1,14 +1,37 @@
 package com.paubox.service;
 
 import java.io.IOException;
+import java.net.URLEncoder;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.paubox.common.Constants;
+import com.paubox.data.CopyFormRequest;
+import com.paubox.data.CreateFormRequest;
+import com.paubox.data.CreateFormResponse;
 import com.paubox.data.Form;
+import com.paubox.data.FormListRequest;
+import com.paubox.data.FormListResponse;
+import com.paubox.data.FormResponse;
+import com.paubox.data.FormStats;
+import com.paubox.data.FormSubmissionListRequest;
+import com.paubox.data.FormSubmissionListResponse;
 import com.paubox.data.FormSubmissionRequest;
+import com.paubox.data.UpdateFormRequest;
+import com.paubox.data.UpdateFormResponse;
 
 public class FormsService implements FormsInterface {
 
     private static final String FORMS_BASE_URL = "https://apx.paubox.com/forms";
+
+    private final String apiKey;
+
+    public FormsService() {
+        this.apiKey = Constants.FORMS_API_KEY;
+    }
+
+    public FormsService(String apiKey) {
+        this.apiKey = apiKey;
+    }
 
     public Form getForm(String formId) throws Exception {
         String url = FORMS_BASE_URL + "/public/form_data/" + formId;
@@ -37,5 +60,195 @@ public class FormsService implements FormsInterface {
         } else if (statusCode != 201) {
             throw new Exception("Unexpected response code: " + statusCode);
         }
+    }
+
+    public FormListResponse listForms(FormListRequest query) throws Exception {
+        StringBuilder queryString = new StringBuilder();
+        if (query != null) {
+            appendParam(queryString, "customer_id", query.getCustomerId());
+            appendParam(queryString, "form_id", query.getFormId());
+            appendParam(queryString, "search", query.getSearch());
+            appendParam(queryString, "order", query.getOrder());
+            appendParam(queryString, "order_by", query.getOrderBy());
+            appendParam(queryString, "archived", query.getArchived());
+            appendParam(queryString, "active", query.getActive());
+            appendParam(queryString, "page", query.getPage());
+            appendParam(queryString, "items", query.getItems());
+        }
+        String url = FORMS_BASE_URL + "/api/forms" + queryString.toString();
+        String responseStr = APIHelper.callToAPIByGet(url, authHeader());
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        FormListResponse response = mapper.readValue(responseStr, FormListResponse.class);
+        if (response.getResults() == null || response.getPageInfo() == null) {
+            throw new IOException(responseStr);
+        }
+        return response;
+    }
+
+    public String createForm(CreateFormRequest request) throws Exception {
+        if (request == null) {
+            throw new Exception("CreateFormRequest cannot be null.");
+        }
+        if (request.getTitle() == null || request.getFormJson() == null
+                || request.getCustomerId() == null || request.getVersion() == null) {
+            throw new Exception("title, form_json, customer_id and version cannot be null.");
+        }
+        String url = FORMS_BASE_URL + "/api/forms";
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        String requestBody = mapper.writeValueAsString(request);
+        String responseStr = APIHelper.callToAPIByPost(url, authHeader(), requestBody);
+        CreateFormResponse response = mapper.readValue(responseStr, CreateFormResponse.class);
+        if (response.getId() == null) {
+            throw new IOException(responseStr);
+        }
+        return response.getId();
+    }
+
+    public Form getFormById(String formId) throws Exception {
+        validateId(formId, "formId");
+        String url = FORMS_BASE_URL + "/api/forms/" + formId;
+        String responseStr = APIHelper.callToAPIByGet(url, authHeader());
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        FormResponse response = mapper.readValue(responseStr, FormResponse.class);
+        if (response.getData() == null || response.getData().getId() == null) {
+            throw new IOException(responseStr);
+        }
+        return response.getData();
+    }
+
+    public UpdateFormResponse updateForm(String formId, UpdateFormRequest request) throws Exception {
+        validateId(formId, "formId");
+        if (request == null) {
+            throw new Exception("UpdateFormRequest cannot be null.");
+        }
+        String url = FORMS_BASE_URL + "/api/forms/" + formId;
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        String requestBody = mapper.writeValueAsString(request);
+        String responseStr = APIHelper.callToAPIByPut(url, authHeader(), requestBody);
+        UpdateFormResponse response = mapper.readValue(responseStr, UpdateFormResponse.class);
+        if (response.getDetail() == null) {
+            throw new IOException(responseStr);
+        }
+        return response;
+    }
+
+    public void archiveForm(String formId) throws Exception {
+        validateId(formId, "formId");
+        String url = FORMS_BASE_URL + "/api/forms/" + formId + "/archive";
+        postWithoutBody(url);
+    }
+
+    public void unarchiveForm(String formId) throws Exception {
+        validateId(formId, "formId");
+        String url = FORMS_BASE_URL + "/api/forms/" + formId + "/unarchive";
+        postWithoutBody(url);
+    }
+
+    public Form copyForm(String formId, String newTitle) throws Exception {
+        validateId(formId, "formId");
+        if (newTitle == null || newTitle.isEmpty()) {
+            throw new Exception("newTitle cannot be null or empty.");
+        }
+        String url = FORMS_BASE_URL + "/api/forms/copy";
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        String requestBody = mapper.writeValueAsString(new CopyFormRequest(formId, newTitle));
+        String responseStr = APIHelper.callToAPIByPost(url, authHeader(), requestBody);
+        Form form = mapper.readValue(responseStr, Form.class);
+        if (form.getId() == null) {
+            throw new IOException(responseStr);
+        }
+        return form;
+    }
+
+    public FormStats getFormStats(Integer customerId) throws Exception {
+        String url = FORMS_BASE_URL + "/api/forms/stats";
+        if (customerId != null) {
+            url = url + "?customer_id=" + customerId;
+        }
+        String responseStr = APIHelper.callToAPIByGet(url, authHeader());
+        if (responseStr == null || !responseStr.contains("\"active_form_count\"")) {
+            throw new IOException(responseStr);
+        }
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        return mapper.readValue(responseStr, FormStats.class);
+    }
+
+    public FormSubmissionListResponse listFormSubmissions(String formId, FormSubmissionListRequest query) throws Exception {
+        validateId(formId, "formId");
+        StringBuilder queryString = new StringBuilder();
+        if (query != null) {
+            appendParam(queryString, "submission_id", query.getSubmissionId());
+            appendParam(queryString, "order", query.getOrder());
+            appendParam(queryString, "order_by", query.getOrderBy());
+            appendParam(queryString, "page", query.getPage());
+            appendParam(queryString, "items", query.getItems());
+        }
+        String url = FORMS_BASE_URL + "/api/forms/" + formId + "/submissions" + queryString.toString();
+        String responseStr = APIHelper.callToAPIByGet(url, authHeader());
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        FormSubmissionListResponse response = mapper.readValue(responseStr, FormSubmissionListResponse.class);
+        if (response.getData() == null) {
+            throw new IOException(responseStr);
+        }
+        return response;
+    }
+
+    public byte[] downloadSubmissionsCsv(String formId) throws Exception {
+        validateId(formId, "formId");
+        String url = FORMS_BASE_URL + "/api/forms/" + formId + "/submissions/submission-csv";
+        return APIHelper.callToAPIByGetBytes(url, authHeader());
+    }
+
+    public byte[] downloadSubmissionCsv(String formId, String submissionId) throws Exception {
+        validateId(formId, "formId");
+        validateId(submissionId, "submissionId");
+        String url = FORMS_BASE_URL + "/api/forms/" + formId + "/submissions/submission-csv/" + submissionId;
+        return APIHelper.callToAPIByGetBytes(url, authHeader());
+    }
+
+    public byte[] downloadSubmissionPdf(String formId, String submissionId) throws Exception {
+        validateId(formId, "formId");
+        validateId(submissionId, "submissionId");
+        String url = FORMS_BASE_URL + "/api/forms/" + formId + "/submissions/" + submissionId + "/submission-pdf";
+        return APIHelper.callToAPIByGetBytes(url, authHeader());
+    }
+
+    private String authHeader() throws Exception {
+        if (apiKey == null || apiKey.isEmpty()) {
+            throw new Exception("A scoped API key with the 'forms' scope is required for this endpoint. "
+                    + "Set FORMSAPIKEY in your config.properties or use new FormsService(apiKey).");
+        }
+        return "Bearer " + apiKey;
+    }
+
+    private void postWithoutBody(String url) throws Exception {
+        String responseStr = APIHelper.callToAPIByPost(url, authHeader(), "");
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+        UpdateFormResponse response = mapper.readValue(responseStr, UpdateFormResponse.class);
+        if (response.getDetail() == null) {
+            throw new IOException(responseStr);
+        }
+    }
+
+    private static void validateId(String value, String name) throws Exception {
+        if (value == null || value.isEmpty()) {
+            throw new Exception(name + " cannot be null or empty.");
+        }
+    }
+
+    private static void appendParam(StringBuilder queryString, String name, Object value) throws Exception {
+        if (value == null) {
+            return;
+        }
+        queryString.append(queryString.length() == 0 ? "?" : "&");
+        queryString.append(name).append("=").append(URLEncoder.encode(String.valueOf(value), "UTF-8"));
     }
 }

--- a/Paubox_Java/paubox-java/src/test/TestFormsService.java
+++ b/Paubox_Java/paubox-java/src/test/TestFormsService.java
@@ -130,6 +130,65 @@ public class TestFormsService {
         new FormsService("").listForms(null);
     }
 
+    // Regression tests: caller-supplied UUID args must be validated before any HTTP call
+    // (paubox-java QA gate 2026-08-12 — same class as paubox-python3 #10 and paubox-php #16).
+
+    private static final String HOSTILE_DOT_DOT = "../../etc/passwd";
+    private static final String HOSTILE_QUERY = "11111111-1111-1111-1111-111111111111?admin=1";
+    private static final String HOSTILE_FRAGMENT = "11111111-1111-1111-1111-111111111111#frag";
+
+    @Test(expected = Exception.class)
+    public void testGetFormByIdRejectsHostileFormId() throws Exception {
+        new FormsService("unused-key").getFormById(HOSTILE_DOT_DOT);
+    }
+
+    @Test(expected = Exception.class)
+    public void testGetFormByIdRejectsQuerySplice() throws Exception {
+        new FormsService("unused-key").getFormById(HOSTILE_QUERY);
+    }
+
+    @Test(expected = Exception.class)
+    public void testGetFormByIdRejectsFragmentSplice() throws Exception {
+        new FormsService("unused-key").getFormById(HOSTILE_FRAGMENT);
+    }
+
+    @Test(expected = Exception.class)
+    public void testUpdateFormRejectsHostileFormId() throws Exception {
+        new FormsService("unused-key").updateForm(HOSTILE_DOT_DOT, new UpdateFormRequest());
+    }
+
+    @Test(expected = Exception.class)
+    public void testArchiveFormRejectsHostileFormId() throws Exception {
+        new FormsService("unused-key").archiveForm(HOSTILE_DOT_DOT);
+    }
+
+    @Test(expected = Exception.class)
+    public void testUnarchiveFormRejectsHostileFormId() throws Exception {
+        new FormsService("unused-key").unarchiveForm(HOSTILE_DOT_DOT);
+    }
+
+    @Test(expected = Exception.class)
+    public void testListFormSubmissionsRejectsHostileFormId() throws Exception {
+        new FormsService("unused-key").listFormSubmissions(HOSTILE_DOT_DOT, null);
+    }
+
+    @Test(expected = Exception.class)
+    public void testDownloadSubmissionsCsvRejectsHostileFormId() throws Exception {
+        new FormsService("unused-key").downloadSubmissionsCsv(HOSTILE_DOT_DOT);
+    }
+
+    @Test(expected = Exception.class)
+    public void testDownloadSubmissionCsvRejectsHostileSubmissionId() throws Exception {
+        new FormsService("unused-key").downloadSubmissionCsv(
+                "11111111-1111-1111-1111-111111111111", HOSTILE_DOT_DOT);
+    }
+
+    @Test(expected = Exception.class)
+    public void testDownloadSubmissionPdfRejectsHostileSubmissionId() throws Exception {
+        new FormsService("unused-key").downloadSubmissionPdf(
+                "11111111-1111-1111-1111-111111111111", HOSTILE_DOT_DOT);
+    }
+
     @Test
     public void testFormLifecycle() throws Exception {
         if (formsApiKey == null || formsApiKey.isEmpty()) return;

--- a/Paubox_Java/paubox-java/src/test/TestFormsService.java
+++ b/Paubox_Java/paubox-java/src/test/TestFormsService.java
@@ -12,17 +12,28 @@ import java.util.Map;
 import org.junit.BeforeClass;
 import org.junit.Test;
 
+import com.paubox.data.CreateFormRequest;
 import com.paubox.data.Form;
+import com.paubox.data.FormListRequest;
+import com.paubox.data.FormListResponse;
+import com.paubox.data.FormStats;
+import com.paubox.data.FormSubmission;
 import com.paubox.data.FormSubmissionAttachment;
+import com.paubox.data.FormSubmissionListResponse;
 import com.paubox.data.FormSubmissionRequest;
+import com.paubox.data.UpdateFormRequest;
+import com.paubox.data.UpdateFormResponse;
 import com.paubox.service.FormsInterface;
 import com.paubox.service.FormsService;
 
 public class TestFormsService {
 
     static FormsInterface forms = new FormsService();
+    static FormsInterface authForms;
     static String validFormId;
     static String invalidFormId = "00000000-0000-0000-0000-000000000000";
+    static String formsApiKey;
+    static String customerId;
 
     @BeforeClass
     public static void init() {
@@ -34,8 +45,15 @@ public class TestFormsService {
             java.util.Properties props = new java.util.Properties();
             props.load(new java.io.FileInputStream(propertiesFile));
             validFormId = props.getProperty("FORM_ID");
+            formsApiKey = props.getProperty("FORMSAPIKEY");
+            customerId = props.getProperty("CUSTOMER_ID");
         } catch (Exception e) {
             validFormId = null;
+            formsApiKey = null;
+            customerId = null;
+        }
+        if (formsApiKey != null && !formsApiKey.isEmpty()) {
+            authForms = new FormsService(formsApiKey);
         }
     }
 
@@ -92,5 +110,110 @@ public class TestFormsService {
         submission.setAttachments(attachments);
 
         forms.submitForm(validFormId, submission);
+    }
+
+    @Test
+    public void testListFormsForSuccess() throws Exception {
+        if (formsApiKey == null || formsApiKey.isEmpty()) return;
+        if (customerId == null || customerId.isEmpty()) return;
+        FormListRequest query = new FormListRequest();
+        query.setCustomerId(Integer.valueOf(customerId));
+        query.setItems(10);
+        FormListResponse response = authForms.listForms(query);
+        assertNotNull(response);
+        assertNotNull(response.getResults());
+        assertNotNull(response.getPageInfo());
+    }
+
+    @Test(expected = Exception.class)
+    public void testListFormsWithoutApiKeyThrows() throws Exception {
+        new FormsService("").listForms(null);
+    }
+
+    @Test
+    public void testFormLifecycle() throws Exception {
+        if (formsApiKey == null || formsApiKey.isEmpty()) return;
+        if (customerId == null || customerId.isEmpty()) return;
+
+        Map<String, Object> formJson = new HashMap<String, Object>();
+        formJson.put("body", new ArrayList<Object>());
+        CreateFormRequest createRequest = new CreateFormRequest("paubox-java SDK test form",
+                formJson, Integer.valueOf(customerId), 1);
+        createRequest.setActive(false);
+
+        String formId = authForms.createForm(createRequest);
+        assertNotNull(formId);
+
+        String copiedFormId = null;
+        try {
+            Form form = authForms.getFormById(formId);
+            assertNotNull(form);
+            assertEquals(formId, form.getId());
+            assertEquals("paubox-java SDK test form", form.getTitle());
+
+            UpdateFormRequest updateRequest = new UpdateFormRequest();
+            updateRequest.setTitle("paubox-java SDK test form (updated)");
+            UpdateFormResponse updateResponse = authForms.updateForm(formId, updateRequest);
+            assertNotNull(updateResponse);
+            assertNotNull(updateResponse.getDetail());
+
+            Form copiedForm = authForms.copyForm(formId, "paubox-java SDK test form (copy)");
+            assertNotNull(copiedForm);
+            assertNotNull(copiedForm.getId());
+            copiedFormId = copiedForm.getId();
+            assertTrue(!formId.equals(copiedFormId));
+        } finally {
+            try {
+                authForms.archiveForm(formId);
+            } finally {
+                if (copiedFormId != null) {
+                    authForms.archiveForm(copiedFormId);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testGetFormStats() throws Exception {
+        if (formsApiKey == null || formsApiKey.isEmpty()) return;
+        FormStats stats = authForms.getFormStats(null);
+        assertNotNull(stats);
+        assertTrue(stats.getActiveFormCount() >= 0);
+        assertTrue(stats.getTotalSubmissionCount() >= 0);
+        assertTrue(stats.getSubmissionsLast7Days() >= 0);
+    }
+
+    @Test
+    public void testListFormSubmissions() throws Exception {
+        if (formsApiKey == null || formsApiKey.isEmpty()) return;
+        if (validFormId == null || validFormId.isEmpty()) return;
+        FormSubmissionListResponse response = authForms.listFormSubmissions(validFormId, null);
+        assertNotNull(response);
+        assertNotNull(response.getData());
+    }
+
+    @Test
+    public void testDownloadSubmissionsCsv() throws Exception {
+        if (formsApiKey == null || formsApiKey.isEmpty()) return;
+        if (validFormId == null || validFormId.isEmpty()) return;
+        byte[] csv = authForms.downloadSubmissionsCsv(validFormId);
+        assertNotNull(csv);
+        assertTrue(csv.length > 0);
+    }
+
+    @Test
+    public void testDownloadSubmissionPdf() throws Exception {
+        if (formsApiKey == null || formsApiKey.isEmpty()) return;
+        if (validFormId == null || validFormId.isEmpty()) return;
+        FormSubmissionListResponse response = authForms.listFormSubmissions(validFormId, null);
+        assertNotNull(response);
+        assertNotNull(response.getData());
+        if (response.getData().isEmpty()) return;
+        FormSubmission submission = response.getData().get(0);
+        byte[] pdf = authForms.downloadSubmissionPdf(validFormId, submission.getId());
+        assertNotNull(pdf);
+        assertTrue(pdf.length > 0);
+        assertTrue(pdf.length >= 4);
+        assertTrue(pdf[0] == '%' && pdf[1] == 'P' && pdf[2] == 'D' && pdf[3] == 'F');
     }
 }

--- a/Paubox_Java/paubox-java/src/test/config.properties.sample
+++ b/Paubox_Java/paubox-java/src/test/config.properties.sample
@@ -3,3 +3,6 @@ APIUSER=<api user>
 BASE_URL=<microservice base URL>
 RECIPIENTS=<test@test.com where you want the email to go to >
 PDFFILE=src/test/testFile.pdf # for pdf attachment test
+FORMSAPIKEY=<scoped API key with the forms scope - required for Forms management endpoints>
+FORM_ID=<uuid of an existing form - for forms tests>
+CUSTOMER_ID=<your Paubox customer id - for the form create/update tests>

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ The API wrapper allows you to construct and send messages.
   * [Sending messages](#sending-messages)
   * [Checking Email Dispositions](#checking-email-dispositions)
   * [Paubox Forms](#paubox-forms)
+    * [Respondent endpoints](#forms-respondent-endpoints)
+    * [Forms management](#forms-management)
 * [Contributing](#contributing)
 * [License](#license)
 
@@ -232,9 +234,32 @@ static void GetEmailDisposition()
 <a name="paubox-forms"></a>
 ## Paubox Forms
 
-Paubox Forms is a secure form product included with Paubox Email Suite. The Forms API requires **no API key** — the endpoints are public and called on behalf of form respondents.
+Paubox Forms is a secure form product included with Paubox Email Suite. The Forms API has two kinds of endpoints:
 
-### Getting a form definition
+- **Respondent endpoints** — getting a form's public definition and submitting a response require **no API key**. They are public and called on behalf of form respondents.
+- **Forms management endpoints** — listing, creating, updating, archiving, and copying forms, plus stats and reading/exporting submissions, require a **scoped API key** with the `forms` scope, created in the Paubox admin dashboard.
+
+Pass the scoped API key either explicitly:
+
+```java
+FormsInterface forms = new FormsService("Your-Scoped-API-Key-Here");
+```
+
+or via the `FORMSAPIKEY` property in your configuration file, then use the no-arg constructor:
+
+```java
+FORMSAPIKEY: Your-Scoped-API-Key-Here
+```
+
+```java
+ConfigurationManager.getProperties("/path/to/config.properties");
+FormsInterface forms = new FormsService();
+```
+
+<a name="forms-respondent-endpoints"></a>
+### Respondent endpoints
+
+#### Getting a form definition
 
 Retrieve a form's HTML, JSON schema, and CSS before rendering it:
 
@@ -252,7 +277,7 @@ static Form GetForm(String formId) throws Exception {
 }
 ```
 
-### Submitting a form response
+#### Submitting a form response
 
 Submit a respondent's answers. The `formData` keys must match the field names in the form's JSON schema (`form.getFormJson()`):
 
@@ -275,7 +300,7 @@ static void SubmitForm(String formId) throws Exception {
 }
 ```
 
-### Submitting with file attachments
+#### Submitting with file attachments
 
 ```java
 import com.paubox.data.FormSubmissionAttachment;
@@ -306,6 +331,184 @@ static void SubmitFormWithAttachment(String formId) throws Exception {
 ```
 
 Maximum submission size is **250 MB** to accommodate file attachments.
+
+<a name="forms-management"></a>
+### Forms management
+
+All of the methods below require a **scoped API key** with the `forms` scope. Construct the service with `new FormsService(apiKey)`, or set the `FORMSAPIKEY` property and use `new FormsService()`.
+
+#### Listing forms
+
+List your forms with optional filtering and pagination. When authenticating with a scoped API key, `customerId` must be set to your own Paubox customer id — omitting it results in a `403 Forbidden` from the API. The other filters are optional (defaults: page 1, 50 items, newest first):
+
+```java
+import com.paubox.data.Form;
+import com.paubox.data.FormListRequest;
+import com.paubox.data.FormListResponse;
+import com.paubox.service.FormsInterface;
+import com.paubox.service.FormsService;
+
+static void ListForms() throws Exception {
+    FormListRequest query = new FormListRequest();
+    query.setCustomerId(12345); // your Paubox customer id — required with a scoped API key
+    query.setSearch("intake");
+    query.setOrderBy("updated_at");
+    query.setOrder("desc");
+    query.setPage(1);
+    query.setItems(25);
+
+    FormsInterface forms = new FormsService();
+    FormListResponse response = forms.listForms(query);
+
+    for (Form form : response.getResults()) {
+        System.out.println(form.getId() + " - " + form.getTitle());
+    }
+    System.out.println("Total forms: " + response.getPageInfo().getCount()
+            + ", pages: " + response.getPageInfo().getPages());
+}
+```
+
+#### Creating a form
+
+`title`, `formJson`, `customerId`, and `version` are required; everything else is optional. Returns the new form's id:
+
+```java
+import com.paubox.data.CreateFormRequest;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+static String CreateForm() throws Exception {
+    Map<String, Object> formJson = new HashMap<>();
+    formJson.put("body", new ArrayList<Object>());
+
+    CreateFormRequest request = new CreateFormRequest("Patient Intake", formJson, 12345, 1);
+    request.setDescription("New patient intake form");
+    request.setRecipient("intake@yourdomain.com");
+    request.setActive(true);
+
+    FormsInterface forms = new FormsService();
+    String newFormId = forms.createForm(request);
+    return newFormId;
+}
+```
+
+#### Getting a form by id (authenticated)
+
+Unlike the public `getForm`, the authenticated `getFormById` returns the form even when it is inactive or archived:
+
+```java
+static Form GetFormById(String formId) throws Exception {
+    FormsInterface forms = new FormsService();
+    return forms.getFormById(formId);
+}
+```
+
+#### Updating a form
+
+Updates have PATCH semantics — any field you leave `null` on the request stays unchanged:
+
+```java
+import com.paubox.data.UpdateFormRequest;
+import com.paubox.data.UpdateFormResponse;
+
+static void UpdateForm(String formId) throws Exception {
+    UpdateFormRequest request = new UpdateFormRequest();
+    request.setTitle("Patient Intake (v2)");
+    request.setActive(true);
+
+    FormsInterface forms = new FormsService();
+    UpdateFormResponse response = forms.updateForm(formId, request);
+    System.out.println(response.getDetail());
+}
+```
+
+#### Archiving and unarchiving a form
+
+```java
+static void ArchiveAndRestoreForm(String formId) throws Exception {
+    FormsInterface forms = new FormsService();
+    forms.archiveForm(formId);
+    forms.unarchiveForm(formId);
+}
+```
+
+#### Copying a form
+
+Duplicate an existing form under a new title. Returns the full new Form:
+
+```java
+static Form CopyForm(String formId) throws Exception {
+    FormsInterface forms = new FormsService();
+    Form copy = forms.copyForm(formId, "Patient Intake (copy)");
+    return copy;
+}
+```
+
+#### Form stats
+
+Get aggregate counts for your forms. Pass `null` to use the customer associated with your API key, or an explicit customer id:
+
+```java
+import com.paubox.data.FormStats;
+
+static void GetFormStats() throws Exception {
+    FormsInterface forms = new FormsService();
+    FormStats stats = forms.getFormStats(null);
+    System.out.println("Active forms: " + stats.getActiveFormCount());
+    System.out.println("Total submissions: " + stats.getTotalSubmissionCount());
+    System.out.println("Submissions in the last 7 days: " + stats.getSubmissionsLast7Days());
+}
+```
+
+#### Listing form submissions
+
+List a form's submissions with optional filtering and pagination. Pass `null` instead of a `FormSubmissionListRequest` to use all defaults:
+
+```java
+import com.paubox.data.FormSubmission;
+import com.paubox.data.FormSubmissionListRequest;
+import com.paubox.data.FormSubmissionListResponse;
+
+static void ListFormSubmissions(String formId) throws Exception {
+    FormSubmissionListRequest query = new FormSubmissionListRequest();
+    query.setOrder("desc");
+    query.setItems(20);
+
+    FormsInterface forms = new FormsService();
+    FormSubmissionListResponse response = forms.listFormSubmissions(formId, query);
+
+    for (FormSubmission submission : response.getData()) {
+        System.out.println(submission.getId() + " - " + submission.getSubmitterEmail());
+    }
+    System.out.println("Total submissions: " + response.getTotal());
+}
+```
+
+#### Downloading submissions as CSV or PDF
+
+Export all of a form's submissions (or a single submission) as CSV, or a single submission as PDF. The methods return the raw file bytes:
+
+```java
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+static void DownloadSubmissions(String formId, String submissionId) throws Exception {
+    FormsInterface forms = new FormsService();
+
+    // All submissions of a form, as CSV
+    byte[] csv = forms.downloadSubmissionsCsv(formId);
+    Files.write(Paths.get("submissions.csv"), csv);
+
+    // A single submission, as CSV
+    byte[] oneCsv = forms.downloadSubmissionCsv(formId, submissionId);
+    Files.write(Paths.get("submission.csv"), oneCsv);
+
+    // A single submission, as PDF
+    byte[] pdf = forms.downloadSubmissionPdf(formId, submissionId);
+    Files.write(Paths.get("submission.pdf"), pdf);
+}
+```
 
 <a name="#contributing"></a>
 ## Contributing

--- a/api.md
+++ b/api.md
@@ -112,21 +112,45 @@ GetEmailDispositionResponse response = email.getEmailDisposition(sourceTrackingI
 ## Forms API
 
 Base URL: `https://apx.paubox.com/forms`  
-Authentication: **None required**
+Authentication: **None** for respondent endpoints (`getForm`, `submitForm`); **scoped API key** for all other methods
+
+#### Authentication
+
+Respondent endpoints (`getForm`, `submitForm`) are public — no credentials needed.
+
+All other Forms methods (management endpoints) require a **scoped API key** with the `forms` scope, created in the Paubox admin dashboard. The SDK sends it as `Authorization: Bearer {FORMS_API_KEY}`. Calling a management method without a key throws `Exception`.
 
 ### Setup
+
+Respondent endpoints (public):
 
 ```java
 FormsInterface forms = new FormsService();
 ```
 
-No credentials needed — these endpoints are public.
+Management endpoints — pass the scoped API key explicitly:
+
+```java
+FormsInterface forms = new FormsService("your-scoped-api-key");
+```
+
+...or set `FORMSAPIKEY` in `config.properties` and use the no-arg constructor:
+
+```java
+ConfigurationManager.getProperties("/path/to/config.properties");
+FormsInterface forms = new FormsService();
+```
+
+`config.properties` (only needed for management endpoints):
+```
+FORMSAPIKEY=your-scoped-api-key
+```
 
 ---
 
 ### getForm
 
-Retrieve the full definition of a form (HTML, JSON schema, CSS).
+Retrieve the full definition of a form (HTML, JSON schema, CSS). Public — no API key. Only returns active, non-archived forms; use [`getFormById`](#getformbyid) to fetch a form regardless of state.
 
 ```java
 Form form = forms.getForm("550e8400-e29b-41d4-a716-446655440000");
@@ -152,10 +176,13 @@ Form form = forms.getForm("550e8400-e29b-41d4-a716-446655440000");
 | `version` | `int` | Schema version |
 | `active` | `boolean` | Whether the form accepts submissions |
 | `customerId` | `int` | Owning customer ID |
+| `recipient` | `String` | Comma-separated emails notified on submission |
 | `signable` | `boolean` | Whether the form has a signature field |
 | `signatureConfirmationLabel` | `String` | Label for signature confirmation |
 | `submissionCount` | `int` | Total submissions received |
-| `type` | `String` | Optional form type |
+| `type` | `String` | Optional form type (e.g. `marketing_form`) |
+| `subscriptionListId` | `String` | Optional marketing subscription list ID |
+| `oldFormId` | `Integer` | Legacy form ID, if migrated |
 | `deleted` | `boolean` | Whether the form is soft-deleted |
 | `archived` | `boolean` | Whether the form is archived |
 | `createdAt` | `String` | ISO 8601 creation timestamp |
@@ -167,7 +194,7 @@ Throws `IOException` if the form is not found (404).
 
 ### submitForm
 
-Submit a respondent's answers for a form. On success the service stores the submission, increments the form's submission count, and emails recipients if configured.
+Submit a respondent's answers for a form. Public — no API key. On success the service stores the submission, increments the form's submission count, and emails recipients if configured.
 
 ```java
 Map<String, Object> data = new HashMap<>();
@@ -219,3 +246,318 @@ forms.submitForm(formId, submission);
 ```
 
 Returns `void` on success (HTTP 201). Throws `Exception` on 400 (missing `form_data`) or 404 (form not found).
+
+---
+
+### listForms
+
+Requires a scoped API key. List forms with optional filtering and pagination.
+
+```java
+FormListResponse response = forms.listForms(query);
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `query` | `FormListRequest` | Filters/pagination; `customerId` is required when authenticating with a scoped API key |
+
+**FormListRequest fields** (sent as query parameters, not JSON)
+
+| Field | Type | Description |
+|---|---|---|
+| `customerId` | `Integer` | Customer ID to list forms for. **Required with a scoped API key** — must equal the key's customer id, otherwise the API returns `403 Forbidden` |
+| `formId` | `String` | Filter to a single form UUID |
+| `search` | `String` | Substring match against title/description |
+| `order` | `String` | `asc` or `desc` (default `desc`) |
+| `orderBy` | `String` | `title`, `updated_at`, or `submission_count` (default `created_at`) |
+| `archived` | `Boolean` | Filter by archived state |
+| `active` | `Boolean` | Filter by active state |
+| `page` | `Integer` | Page number (default 1) |
+| `items` | `Integer` | Items per page (default 50, max 100) |
+
+**FormListResponse fields**
+
+| Field | Type | Description |
+|---|---|---|
+| `results` | `List<Form>` | The forms on this page |
+| `pageInfo` | `PageInfo` | Pagination metadata |
+
+**PageInfo fields**
+
+| Field | Type | Description |
+|---|---|---|
+| `count` | `long` | Total matching forms |
+| `pages` | `int` | Total pages |
+| `page` | `int` | Current page |
+| `items` | `int` | Items per page |
+
+---
+
+### createForm
+
+Requires a scoped API key. Create a new form. Returns the new form's UUID.
+
+```java
+String newFormId = forms.createForm(request);
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `request` | `CreateFormRequest` | The form to create |
+
+**CreateFormRequest fields**
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `title` | `String` | Yes | Form title |
+| `formJson` | `Object` | Yes | JSON schema of the form fields |
+| `customerId` | `Integer` | Yes | Owning customer ID |
+| `version` | `Integer` | Yes | Schema version |
+| `description` | `String` | No | Description |
+| `formHtml` | `String` | No | Rendered HTML of the form |
+| `formCss` | `String` | No | Custom CSS |
+| `recipient` | `String` | No | Comma-separated emails notified on submission |
+| `signable` | `Boolean` | No | Whether the form has a signature field |
+| `signatureConfirmationLabel` | `String` | No | Label for signature confirmation |
+| `subscriptionListId` | `String` | No | Marketing subscription list ID |
+| `type` | `String` | No | Form type (e.g. `marketing_form`) |
+| `active` | `Boolean` | No | Whether the form accepts submissions |
+| `submissionCount` | `Integer` | No | Initial submission count |
+
+The convenience constructor `CreateFormRequest(String title, Object formJson, Integer customerId, Integer version)` sets the four required fields.
+
+Throws `Exception` if `request`, `title`, `formJson`, `customerId`, or `version` is missing.
+
+---
+
+<a name="getformbyid"></a>
+### getFormById
+
+Requires a scoped API key. Retrieve a form by ID regardless of its active/archived state (unlike the public `getForm`).
+
+```java
+Form form = forms.getFormById(formId);
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `formId` | `String` | UUID of the form |
+
+Returns a `Form` (same fields as [`getForm`](#getform)). Throws `IOException` if the form is not found (404).
+
+---
+
+### updateForm
+
+Requires a scoped API key. Update a form. PATCH semantics: fields left `null` on the request stay unchanged.
+
+```java
+UpdateFormResponse response = forms.updateForm(formId, request);
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `formId` | `String` | UUID of the form to update |
+| `request` | `UpdateFormRequest` | Fields to change (null = leave unchanged) |
+
+**UpdateFormRequest fields** (all optional)
+
+| Field | Type | Description |
+|---|---|---|
+| `title` | `String` | New title |
+| `description` | `String` | New description |
+| `formJson` | `Object` | New JSON schema |
+| `vanityUrl` | `String` | New vanity URL slug |
+| `recipient` | `String` | Comma-separated notification emails |
+| `active` | `Boolean` | Enable/disable submissions |
+| `subscriptionListId` | `String` | Marketing subscription list ID |
+
+**UpdateFormResponse fields**
+
+| Field | Type | Description |
+|---|---|---|
+| `detail` | `String` | e.g. `"Form updated successfully"` |
+| `formId` | `String` | UUID of the updated form |
+
+Throws `IOException` if the form is not found (404).
+
+---
+
+### archiveForm / unarchiveForm
+
+Requires a scoped API key. Archive or unarchive a form. No request body; returns `void`.
+
+```java
+forms.archiveForm(formId);
+forms.unarchiveForm(formId);
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `formId` | `String` | UUID of the form |
+
+Throws `IOException` on error (e.g. form not found).
+
+---
+
+### copyForm
+
+Requires a scoped API key. Duplicate an existing form under a new title. Returns the full new `Form`.
+
+```java
+Form copy = forms.copyForm(formId, "New title");
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `formId` | `String` | UUID of the source form |
+| `newTitle` | `String` | Title for the copy |
+
+Throws `IOException` if the source form is not found (404).
+
+---
+
+### getFormStats
+
+Requires a scoped API key. Get aggregate form/submission counts.
+
+```java
+FormStats stats = forms.getFormStats(null);
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `customerId` | `Integer` | Optional customer ID; `null` uses the API key's customer |
+
+**FormStats fields**
+
+| Field | Type | Description |
+|---|---|---|
+| `activeFormCount` | `long` | Number of active forms |
+| `totalSubmissionCount` | `long` | Total submissions across forms |
+| `submissionsLast7Days` | `long` | Submissions in the last 7 days |
+
+---
+
+### listFormSubmissions
+
+Requires a scoped API key. List a form's submissions with optional filtering and pagination.
+
+```java
+FormSubmissionListResponse response = forms.listFormSubmissions(formId, query);
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `formId` | `String` | UUID of the form |
+| `query` | `FormSubmissionListRequest` | Optional filters/pagination; pass `null` for all defaults |
+
+**FormSubmissionListRequest fields** (all optional; sent as query parameters, not JSON)
+
+| Field | Type | Description |
+|---|---|---|
+| `submissionId` | `String` | Filter to a single submission |
+| `order` | `String` | `asc` or `desc` |
+| `orderBy` | `String` | `submitter_email` (default `created_at`) |
+| `page` | `Integer` | Page number (default 1) |
+| `items` | `Integer` | Items per page (default 50, max 100) |
+
+**FormSubmissionListResponse fields**
+
+| Field | Type | Description |
+|---|---|---|
+| `data` | `List<FormSubmission>` | The submissions on this page |
+| `total` | `long` | Total matching submissions |
+| `page` | `int` | Current page |
+| `items` | `int` | Items per page |
+
+**FormSubmission fields**
+
+| Field | Type | Description |
+|---|---|---|
+| `id` | `String` | Submission UUID |
+| `formId` | `String` | UUID of the form |
+| `formData` | `String` | The submission's answers as a JSON string |
+| `storageType` | `String` | Where the submission is stored |
+| `storageUrl` | `String` | Storage URL (nullable) |
+| `submitterEmail` | `String` | Respondent's email (nullable) |
+| `recipients` | `String` | Notified recipients (nullable) |
+| `attachment` | `String` | Attachment reference (nullable) |
+| `attachmentName` | `String` | Attachment filename (nullable) |
+| `attachmentUrl` | `String` | Attachment URL (nullable) |
+| `attachmentType` | `String` | Attachment MIME type (nullable) |
+| `createdAt` | `String` | ISO 8601 creation timestamp |
+
+Throws `IOException` if the form is not found (404).
+
+---
+
+### downloadSubmissionsCsv
+
+Requires a scoped API key. Download all of a form's submissions as CSV. Returns the raw `text/csv` bytes.
+
+```java
+byte[] csv = forms.downloadSubmissionsCsv(formId);
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `formId` | `String` | UUID of the form |
+
+Throws `Exception` on a non-200 response.
+
+---
+
+### downloadSubmissionCsv
+
+Requires a scoped API key. Download a single submission as CSV. Returns the raw `text/csv` bytes.
+
+```java
+byte[] csv = forms.downloadSubmissionCsv(formId, submissionId);
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `formId` | `String` | UUID of the form |
+| `submissionId` | `String` | UUID of the submission |
+
+Throws `Exception` on a non-200 response.
+
+---
+
+### downloadSubmissionPdf
+
+Requires a scoped API key. Download a single submission as PDF. Returns the raw `application/pdf` bytes.
+
+```java
+byte[] pdf = forms.downloadSubmissionPdf(formId, submissionId);
+```
+
+**Parameters**
+
+| Parameter | Type | Description |
+|---|---|---|
+| `formId` | `String` | UUID of the form |
+| `submissionId` | `String` | UUID of the submission |
+
+Throws `Exception` on a non-200 response.


### PR DESCRIPTION
## Summary

The Paubox Forms API supports **scoped API keys** — opaque keys with the `forms` scope, sent as `Authorization: Bearer <key>` — for its authenticated management endpoints. This PR adds full SDK coverage for that surface (previously the SDK only covered the two public respondent endpoints).

## What's new

**12 new `FormsService` methods** (all requiring a scoped API key):

| Method | Endpoint |
|---|---|
| `listForms(FormListRequest)` | `GET /api/forms` — pagination, search, filters |
| `createForm(CreateFormRequest)` | `POST /api/forms` |
| `getFormById(String)` | `GET /api/forms/:id` — sees archived/inactive forms |
| `updateForm(String, UpdateFormRequest)` | `PUT /api/forms/:id` — PATCH semantics (null = unchanged) |
| `archiveForm(String)` / `unarchiveForm(String)` | `POST /api/forms/:id/archive` / `/unarchive` |
| `copyForm(String, String)` | `POST /api/forms/copy` |
| `getFormStats(Integer)` | `GET /api/forms/stats` |
| `listFormSubmissions(String, FormSubmissionListRequest)` | `GET /api/forms/:form_id/submissions` |
| `downloadSubmissionsCsv` / `downloadSubmissionCsv` | CSV export (all / single submission) |
| `downloadSubmissionPdf` | PDF export of a single submission |

**Scoped API key support**
- `new FormsService(apiKey)` for an explicit key, or set `FORMSAPIKEY` in `config.properties` and use the no-arg constructor.
- Authenticated methods throw a clear error when no key is configured.
- The existing public `getForm` / `submitForm` behavior is unchanged.

**Supporting changes**
- 13 new DTOs (list/create/update/copy requests and responses, `PageInfo`, `FormStats`, `FormSubmission`, …).
- `Form` model gains `recipient`, `old_form_id`, `subscription_list_id`.
- `APIHelper` gains `callToAPIByPut` and `callToAPIByGetBytes` (binary downloads).
- New live-API tests in `TestFormsService` (skip when `FORMSAPIKEY` is unconfigured) + updated `config.properties.sample`.
- Full documentation in `README.md`, `api.md`, and `CLAUDE.md`.

## Notable backend behavior encoded here

`GET /api/forms` returns **403 unless `customer_id` is passed and matches the API key's customer** — scoped keys carry no roles, so the backend's ownership check needs the explicit param. `listForms` docs, examples, and tests all set `customerId` accordingly.

## Verification

- `mvn package` builds the fat JAR cleanly.
- Test sources (excluded from Maven compilation) compile cleanly via `javac` against the built JAR + JUnit 4.13.1.
- Live-API tests require real credentials (`FORMSAPIKEY`, `CUSTOMER_ID`, `FORM_ID`) and were not run here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PtBy2qoe47974ygnRaef6c

---
_Generated by [Claude Code](https://claude.ai/code/session_01PtBy2qoe47974ygnRaef6c)_