### PR TITLE
Remove username from API auth and move base URLs to api.paubox.com

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,8 +6,8 @@ Developer context for working on this SDK.
 
 This repo is the official Java wrapper for two Paubox APIs:
 
-- **Paubox Email API** — send HIPAA-compliant emails, check delivery status. Requires an API key and username. Base URL: `https://api.paubox.net/v1/{API_USER}/`
-- **Paubox Forms API** — retrieve form definitions, submit responses, and manage forms/submissions. Public respondent endpoints (get public form data, submit) need no key; management endpoints (list/create/update/archive/copy forms, stats, submissions, CSV/PDF export) need a scoped API key with the `forms` scope. Base URL: `https://apx.paubox.com/forms`
+- **Paubox Email API** — send HIPAA-compliant emails, check delivery status. Requires an API key. Base URL: `https://api.paubox.com/v1/`
+- **Paubox Forms API** — retrieve form definitions, submit responses, and manage forms/submissions. Public respondent endpoints (get public form data, submit) need no key; management endpoints (list/create/update/archive/copy forms, stats, submissions, CSV/PDF export) need a scoped API key with the `forms` scope. Base URL: `https://api.paubox.com/forms`
 
 ## Project Layout
 
@@ -53,7 +53,6 @@ Required properties for email tests:
 
 ```
 APIKEY=your-api-key
-APIUSER=your-api-username
 RECIPIENTS=recipient@example.com
 PDFFILE=src/test/testFile.pdf
 ```

--- a/Paubox_Java/paubox-java/src/com/paubox/common/Constants.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/common/Constants.java
@@ -4,12 +4,11 @@ public class Constants {
 
 	public static String API_KEY;
 	public static String FORMS_API_KEY;
-	public  static String API_USER;
-	
+
 	public  final static  String TYPE_GET="GET";
 	public  final static  String TYPE_POST="POST";
 	
 	public  final static  int HTTP_STATUS_SUCCESS = 200;
 
-	public  final static  String FORMS_BASE_URL = "https://apx.paubox.com/forms";
+	public  final static  String FORMS_BASE_URL = "https://api.paubox.com/forms";
 }

--- a/Paubox_Java/paubox-java/src/com/paubox/config/ConfigurationManager.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/config/ConfigurationManager.java
@@ -31,7 +31,6 @@ public class ConfigurationManager {
 	private static void setConstants(Properties properties){
 		
 		Constants.API_KEY=properties.getProperty("APIKEY");
-		Constants.API_USER=properties.getProperty("APIUSER");
 		Constants.FORMS_API_KEY = properties.getProperty("FORMSAPIKEY");
 		
 	}

--- a/Paubox_Java/paubox-java/src/com/paubox/service/EmailService.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/service/EmailService.java
@@ -15,7 +15,7 @@ import org.json.simple.JSONArray;
 
 public class EmailService implements EmailInterface {
 
-	private String baseApiUrl = "https://api.paubox.net/v1/" + Constants.API_USER + "/";
+	private String baseApiUrl = "https://api.paubox.com/v1/";
 
 	public GetEmailDispositionResponse getEmailDisposition(String sourceTrackingId) throws Exception {
 		String url = baseApiUrl + "message_receipt?sourceTrackingId=" + sourceTrackingId;

--- a/Paubox_Java/paubox-java/src/com/paubox/service/FormsService.java
+++ b/Paubox_Java/paubox-java/src/com/paubox/service/FormsService.java
@@ -22,7 +22,7 @@ import com.paubox.data.UpdateFormResponse;
 
 public class FormsService implements FormsInterface {
 
-    private static final String FORMS_BASE_URL = "https://apx.paubox.com/forms";
+    private static final String FORMS_BASE_URL = "https://api.paubox.com/forms";
     private static final Pattern UUID_PATTERN = Pattern.compile("^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$");
 
     private final String apiKey;

--- a/Paubox_Java/paubox-java/src/test/TestAPIHelper.java
+++ b/Paubox_Java/paubox-java/src/test/TestAPIHelper.java
@@ -31,7 +31,7 @@ public class TestAPIHelper extends TestCase {
 			propFile = "src/test/config.properties";
 		}
 		ConfigurationManager.getProperties(propFile);
-		baseUrl = ConfigurationManager.getProperty("BASE_URL") + "/" + ConfigurationManager.getProperty("APIUSER") + "/";
+		baseUrl = ConfigurationManager.getProperty("BASE_URL") + "/";
 		authToken = "Token token=" + ConfigurationManager.getProperty("APIKEY");
 	}
 

--- a/Paubox_Java/paubox-java/src/test/config.properties.sample
+++ b/Paubox_Java/paubox-java/src/test/config.properties.sample
@@ -1,6 +1,5 @@
 APIKEY=<put your API key for paubox here hexadecimal>
-APIUSER=<api user>
-BASE_URL=<microservice base URL>
+BASE_URL=<base URL, e.g. https://api.paubox.com/v1>
 RECIPIENTS=<test@test.com where you want the email to go to >
 PDFFILE=src/test/testFile.pdf # for pdf attachment test
 FORMSAPIKEY=<scoped API key with the forms scope - required for Forms management endpoints>

--- a/README.md
+++ b/README.md
@@ -35,11 +35,10 @@ Once you have an account, follow the instructions on the Rest API dashboard to v
 
 Include your API credentials in a configuration file.
 
-Create a configuration properties file, and add the following 2 properties to this file:
+Create a configuration properties file, and add the following property to this file:
 
 ```java
 APIKEY: Your-API-Key-Here
-APIUSER: Your-Username-Here
 ```
 
 Give the path to this configuration file as input to ConfigurationManager.getProperties()

--- a/api.md
+++ b/api.md
@@ -2,7 +2,7 @@
 
 ## Email API
 
-Base URL: `https://api.paubox.net/v1/{API_USER}/`  
+Base URL: `https://api.paubox.com/v1/`  
 Authentication: `Authorization: Token token={API_KEY}`
 
 ### Setup
@@ -15,7 +15,6 @@ EmailInterface email = new EmailService();
 `config.properties` must contain:
 ```
 APIKEY=your-api-key
-APIUSER=your-api-username
 ```
 
 ---
@@ -111,7 +110,7 @@ GetEmailDispositionResponse response = email.getEmailDisposition(sourceTrackingI
 
 ## Forms API
 
-Base URL: `https://apx.paubox.com/forms`  
+Base URL: `https://api.paubox.com/forms`  
 Authentication: **None** for respondent endpoints (`getForm`, `submitForm`); **scoped API key** for all other methods
 
 #### Authentication


### PR DESCRIPTION
Paubox APIs no longer require a username to authenticate — only the
API key. The Email API base URL drops the {API_USER} path segment and
both the Email and Forms APIs now live on the api.paubox.com host
(previously api.paubox.net and apx.paubox.com).

- EmailService: base URL is now https://api.paubox.com/v1/
- FormsService / Constants: Forms base URL is now https://api.paubox.com/forms
- Constants / ConfigurationManager: API_USER field and APIUSER property removed
- TestAPIHelper / config.properties.sample: username no longer part of test setup
- README, api.md, CLAUDE.md updated to match

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011ZVWggtRHS79bD6s45VqjK