### PR TITLE
ci: build the SDK and compile its tests on every PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,53 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    working-directory: Paubox_Java/paubox-java
+
+jobs:
+  build:
+    name: build (jdk ${{ matrix.jdk }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: ["11", "17", "21"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.jdk }}
+          cache: maven
+
+      - name: Compile the SDK
+        run: mvn -B --no-transfer-progress compile
+
+      - name: Compile the test sources
+        # Compiled but not executed: every test here reads config.properties and
+        # calls the live API. Compiling them catches signature drift between the
+        # SDK and its own tests, which nothing checked before.
+        run: mvn -B --no-transfer-progress test-compile
+
+      - name: Assert the build produced classes
+        # "Nothing to compile" also exits 0, so a green build is not by itself
+        # evidence that anything was built. Floors, not targets.
+        run: |
+          main=$(find target/classes -name '*.class' | wc -l)
+          tests=$(find target/test-classes -name '*.class' | wc -l)
+          echo "main_classes=$main test_classes=$tests"
+          if [ "$main" -lt 30 ] || [ "$tests" -lt 3 ]; then
+            echo "FAIL: expected at least 30 main and 3 test classes" >&2
+            exit 1
+          fi
+          echo "OK: compiled $main main and $tests test classes"

--- a/Paubox_Java/paubox-java/pom.xml
+++ b/Paubox_Java/paubox-java/pom.xml
@@ -5,6 +5,9 @@
   <version>1.2</version>
   <build>
     <sourceDirectory>src</sourceDirectory>
+    <!-- Test sources are excluded from the main compile below; pointing Maven
+         at them lets `test-compile` catch drift between the SDK and its tests. -->
+    <testSourceDirectory>src/test</testSourceDirectory>
     <plugins>
       <plugin>
         <artifactId>maven-compiler-plugin</artifactId>
@@ -16,6 +19,17 @@
         </configuration>
       </plugin>
       
+      <!-- Every test in src/test calls the live API and needs config.properties,
+           so they are not run as part of a build. Set -DskipTests=false to run
+           them deliberately with credentials present. -->
+      <plugin>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.2.5</version>
+        <configuration>
+          <skipTests>true</skipTests>
+        </configuration>
+      </plugin>
+
       <!-- Maven Assembly Plugin -->
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## What

Adds CI — this repo had none, so nothing verified the SDK even compiles. A Maven build across JDK 11, 17 and 21.

Verified: **34 main and 3 test classes compiled** on all three JDKs.

## No tests are run here, deliberately

All **51 JUnit tests** in `src/test` read `config.properties` for an API key, API user, recipients, a form id and a customer id, then call the live API. None can run without credentials, so a build shouldn't attempt them.

They were also **never compiled**: `sourceDirectory` is `src` and the compiler plugin excludes `test/**`, putting the test classes outside the build entirely.

This PR:
- points Maven at them with `<testSourceDirectory>`, so `test-compile` catches drift between the SDK and its own tests
- pins surefire with `<skipTests>true</skipTests>`, so a plain `mvn test` or `mvn package` still won't attempt live calls

Behaviour is unchanged — the tests just have to compile now. `-DskipTests=false` runs them deliberately when credentials are present.

## Note

The build asserts the compiled class counts. `Nothing to compile` also exits 0, so a green build isn't by itself evidence that anything was built.
